### PR TITLE
Add artist profile page with artwork details

### DIFF
--- a/artist-profile.html
+++ b/artist-profile.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Artist Profile - FineArtSuite</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      background: #f8f8f8;
+      color: #333;
+      line-height: 1.6;
+    }
+    header {
+      background: #fff;
+      padding: 1rem;
+      text-align: center;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    main {
+      padding: 1rem;
+      max-width: 960px;
+      margin: auto;
+    }
+    .bio {
+      margin-bottom: 2rem;
+      text-align: center;
+    }
+    .artworks {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+      gap: 1rem;
+    }
+    .artwork {
+      background: #fff;
+      padding: 0.5rem;
+      border-radius: 4px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    }
+    .artwork img {
+      width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .artwork h3 {
+      font-size: 1.1rem;
+      margin: 0.5rem 0 0.25rem;
+    }
+    .artwork p {
+      margin: 0 0 0.25rem;
+    }
+    @media (max-width: 600px) {
+      header {
+        font-size: 1.2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Jane Doe</h1>
+  </header>
+  <main>
+    <section class="bio">
+      <p>Jane Doe is a contemporary painter known for vibrant abstracts and subtle textures that evoke emotion. Her work explores the boundaries between color and form.</p>
+    </section>
+    <section class="artworks">
+      <a class="artwork" href="artwork-1.html">
+        <img src="https://via.placeholder.com/300x300?text=Artwork+1" alt="Artwork 1">
+        <h3>Sunset Dreams</h3>
+        <p>$500</p>
+      </a>
+      <a class="artwork" href="artwork-2.html">
+        <img src="https://via.placeholder.com/300x300?text=Artwork+2" alt="Artwork 2">
+        <h3>Midnight Reflections</h3>
+        <p>$750</p>
+      </a>
+      <a class="artwork" href="artwork-3.html">
+        <img src="https://via.placeholder.com/300x300?text=Artwork+3" alt="Artwork 3">
+        <h3>Ocean Whispers</h3>
+        <p>$600</p>
+      </a>
+    </section>
+  </main>
+</body>
+</html>

--- a/artwork-1.html
+++ b/artwork-1.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sunset Dreams - Jane Doe</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 1rem;
+    }
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>Sunset Dreams</h1>
+  <img src="https://via.placeholder.com/600x600?text=Artwork+1" alt="Sunset Dreams">
+  <p>Price: $500</p>
+  <p><a href="artist-profile.html">Back to profile</a></p>
+</body>
+</html>

--- a/artwork-2.html
+++ b/artwork-2.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Midnight Reflections - Jane Doe</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 1rem;
+    }
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>Midnight Reflections</h1>
+  <img src="https://via.placeholder.com/600x600?text=Artwork+2" alt="Midnight Reflections">
+  <p>Price: $750</p>
+  <p><a href="artist-profile.html">Back to profile</a></p>
+</body>
+</html>

--- a/artwork-3.html
+++ b/artwork-3.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ocean Whispers - Jane Doe</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 1rem;
+    }
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>Ocean Whispers</h1>
+  <img src="https://via.placeholder.com/600x600?text=Artwork+3" alt="Ocean Whispers">
+  <p>Price: $600</p>
+  <p><a href="artist-profile.html">Back to profile</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an artist profile page with mobile-friendly CSS
- add three artwork detail pages linked from the profile page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d400c001483209a5edeb991e771c8