### PR TITLE
Add slug-based gallery loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ python3 -m http.server
 
 After running the command in the project directory, visit `http://localhost:8000` in your browser to view the page.
 
+## Gallery pages
+
+Navigating directly to a path such as `/jenny` or `/leo` will display a simple gallery for that slug using placeholder data from `gallery.js`.
+
 ## Planned gallery features
 
 The current page is only a basic landing page. Future improvements may include:

--- a/gallery.js
+++ b/gallery.js
@@ -1,0 +1,38 @@
+const galleries = {
+  jenny: {
+    title: "Jenny's Gallery",
+    description: "A collection from Jenny.",
+    images: ["/images/jenny1.jpg", "/images/jenny2.jpg"]
+  },
+  leo: {
+    title: "Leo's Gallery",
+    description: "A collection from Leo.",
+    images: ["/images/leo1.jpg", "/images/leo2.jpg"]
+  }
+};
+
+function loadGallery() {
+  const slug = window.location.pathname.replace(/^\//, '').trim();
+  if (!slug || !galleries[slug]) {
+    return;
+  }
+
+  const gallery = galleries[slug];
+  const main = document.querySelector('main');
+  main.innerHTML = `
+    <h1 id="gallery-title">${gallery.title}</h1>
+    <p>${gallery.description}</p>
+    <div id="gallery-images"></div>
+  `;
+  const container = document.getElementById('gallery-images');
+  gallery.images.forEach(src => {
+    const img = document.createElement('img');
+    img.src = src;
+    img.alt = slug;
+    img.style.maxWidth = '150px';
+    img.style.margin = '0.5rem';
+    container.appendChild(img);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadGallery);

--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
       alert("Let's build your gallery!");
     });
   </script>
+  <script src="gallery.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow gallery page to load based on slug from URL
- update landing page to include the new script
- document how to use slug-based gallery pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d40504dc08320b348f9682a20a643