### PR TITLE
Add Express skeleton with EJS templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # FineArtSuite
 
-FineArtSuite is a minimal gallery website project. This repository provides a single HTML file that serves as a starting point for displaying art online.
+FineArtSuite is a minimal gallery website project. It now includes a basic Node.js/Express setup using EJS templates for rendering pages.
 
 ## Running the site locally
 
-Any static file server can be used to host the site. The simplest method is Python's built-in server:
+To run the Express server locally, install the dependencies and start the app:
 
 ```bash
-python3 -m http.server
+npm install
+npm start
 ```
 
-After running the command in the project directory, visit `http://localhost:8000` in your browser to view the page.
+The site will be available at `http://localhost:3000` by default.
 
 ## Gallery pages
 

--- a/app.js
+++ b/app.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const path = require('path');
+
+const publicRoutes = require('./routes/public');
+const adminRoutes = require('./routes/admin');
+
+const app = express();
+
+// view engine setup
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+
+// serve static assets
+app.use(express.static(path.join(__dirname, 'public')));
+
+// routes
+app.use('/', publicRoutes);
+app.use('/admin', adminRoutes);
+
+// start server
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fineartsuite",
+  "version": "1.0.0",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ejs": "^3.1.9"
+  }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,4 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.render('dashboard/index');
+});
+
+router.get('/artists', (req, res) => {
+  res.render('dashboard/artists');
+});
+
+router.get('/artworks', (req, res) => {
+  res.render('dashboard/artworks');
+});
+
+router.get('/settings', (req, res) => {
+  res.render('dashboard/settings');
+});
+
+module.exports = router;

--- a/routes/public.js
+++ b/routes/public.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.render('index');
+});
+
+router.get('/gallery', (req, res) => {
+  res.render('gallery/home');
+});
+
+router.get('/gallery/artist', (req, res) => {
+  res.render('gallery/artist');
+});
+
+router.get('/gallery/artwork', (req, res) => {
+  res.render('gallery/artwork');
+});
+
+module.exports = router;

--- a/views/dashboard/artists.ejs
+++ b/views/dashboard/artists.ejs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Artists</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Artists Management</h1>
+</body>
+</html>

--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Artworks</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Artworks Management</h1>
+</body>
+</html>

--- a/views/dashboard/index.ejs
+++ b/views/dashboard/index.ejs
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Admin Dashboard</h1>
+  <a href="/admin/artists">Artists</a>
+  <a href="/admin/artworks">Artworks</a>
+  <a href="/admin/settings">Settings</a>
+</body>
+</html>

--- a/views/dashboard/settings.ejs
+++ b/views/dashboard/settings.ejs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Settings</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Site Settings</h1>
+</body>
+</html>

--- a/views/gallery/artist.ejs
+++ b/views/gallery/artist.ejs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Artist Page</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Artist Info</h1>
+  <a href="/gallery/artwork">Artwork</a>
+</body>
+</html>

--- a/views/gallery/artwork.ejs
+++ b/views/gallery/artwork.ejs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Artwork Page</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Artwork Details</h1>
+</body>
+</html>

--- a/views/gallery/home.ejs
+++ b/views/gallery/home.ejs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Gallery Home</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Gallery Home</h1>
+  <a href="/gallery/artist">Artist Page</a>
+</body>
+</html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>FineArtSuite</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>Welcome to FineArtSuite</h1>
+  <a href="/gallery">View Gallery</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Node/Express server setup
- create basic routes for public pages and admin dashboard
- add EJS views and a minimal stylesheet
- update README with instructions for running the server

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d431d609c8320b98208007e2fee27