### PR TITLE
Implement in-memory galleries and admin upload page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/server.js
+++ b/server.js
@@ -12,9 +12,10 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(session({ secret: 'gallerysecret', resave: false, saveUninitialized: true }));
 
-// Placeholder data
-const galleries = {
-  'demo-gallery': {
+// Placeholder data stored in-memory
+const galleries = [
+  {
+    slug: 'demo-gallery',
     name: 'Demo Gallery',
     bio: 'Welcome to the demo gallery showcasing placeholder artwork.',
     featuredArtwork: {
@@ -47,11 +48,38 @@ const galleries = {
         ]
       }
     ]
+  },
+  {
+    slug: 'city-gallery',
+    name: 'City Gallery',
+    bio: 'Featuring modern works from local artists.',
+    featuredArtwork: {
+      id: 'c1',
+      title: 'City Lights',
+      image: 'https://via.placeholder.com/600x400?text=City+Lights'
+    },
+    artists: [
+      {
+        id: 'artist2',
+        name: 'John Smith',
+        bio: 'Exploring the geometry of urban life.',
+        artworks: [
+          {
+            id: 'c1',
+            title: 'City Lights',
+            medium: 'Oil on Canvas',
+            dimensions: '24x30',
+            price: '$3500',
+            image: 'https://via.placeholder.com/600x400?text=City+Lights'
+          }
+        ]
+      }
+    ]
   }
-};
+];
 
 function findGallery(slug) {
-  return galleries[slug];
+  return galleries.find(g => g.slug === slug);
 }
 
 function findArtist(gallery, id) {
@@ -64,6 +92,13 @@ function findArtwork(gallery, id) {
     if (art) return { artwork: art, artistId: artist.id };
   }
   return null;
+}
+
+function simulateAuth(req, res, next) {
+  if (!req.session.user) {
+    req.session.user = 'demoAdmin';
+  }
+  next();
 }
 
 function requireLogin(req, res, next) {
@@ -118,6 +153,9 @@ app.get('/logout', (req, res) => {
   });
 });
 
+// Apply fake authentication for all admin routes
+app.use('/dashboard', simulateAuth);
+
 // Admin routes
 app.get('/dashboard', requireLogin, (req, res) => {
   res.render('admin/dashboard');
@@ -129,6 +167,10 @@ app.get('/dashboard/artists', requireLogin, (req, res) => {
 
 app.get('/dashboard/artworks', requireLogin, (req, res) => {
   res.render('admin/artworks');
+});
+
+app.get('/dashboard/upload', requireLogin, (req, res) => {
+  res.render('admin/upload');
 });
 
 app.get('/dashboard/settings', requireLogin, (req, res) => {

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Upload Artwork</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f2f2f2;
+      margin: 0;
+      padding: 0;
+    }
+    .container {
+      max-width: 600px;
+      margin: 2rem auto;
+      background: white;
+      padding: 2rem;
+      border-radius: 5px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    h1 {
+      text-align: center;
+      margin-bottom: 1.5rem;
+    }
+    form label {
+      display: block;
+      margin-top: 1rem;
+    }
+    form input[type="text"],
+    form input[type="number"],
+    form select {
+      width: 100%;
+      padding: 0.5rem;
+      margin-top: 0.3rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+    form input[type="file"] {
+      margin-top: 0.5rem;
+    }
+    form button {
+      margin-top: 1.5rem;
+      padding: 0.7rem 1.2rem;
+      background: #ba0c2f;
+      border: none;
+      color: white;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    #preview {
+      margin-top: 1rem;
+      max-width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Upload Artwork</h1>
+    <form id="upload-form">
+      <label for="title">Title</label>
+      <input type="text" id="title" name="title" required>
+
+      <label for="medium">Medium</label>
+      <input type="text" id="medium" name="medium" required>
+
+      <label for="dimensions">Dimensions</label>
+      <input type="text" id="dimensions" name="dimensions" required>
+
+      <label for="price">Price</label>
+      <input type="number" id="price" name="price" step="0.01" required>
+
+      <label for="image">Image</label>
+      <input type="file" id="image" name="image" accept="image/*" required>
+      <img id="preview" src="" alt="Preview" style="display:none;">
+
+      <label for="status">Status</label>
+      <select id="status" name="status">
+        <option value="available">Available</option>
+        <option value="sold">Sold</option>
+      </select>
+
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+
+  <script>
+    const imageInput = document.getElementById('image');
+    const previewImg = document.getElementById('preview');
+
+    imageInput.addEventListener('change', function() {
+      const file = this.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+          previewImg.src = e.target.result;
+          previewImg.style.display = 'block';
+        };
+        reader.readAsDataURL(file);
+      } else {
+        previewImg.src = '';
+        previewImg.style.display = 'none';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- keep Node dependencies out of version control
- model galleries, artists and artworks using in-memory arrays
- add `simulateAuth` middleware and apply it to admin routes
- serve an upload form with image preview for artworks

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688d4450f470832093fc1ae6bac7eaed