### PR TITLE
Add env-driven credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ npm start
 
 After running the server, visit `http://localhost:3000` in your browser to view the homepage.
 
+### Configuration
+
+The server reads credentials and session configuration from environment variables. These are optional and default to development-friendly values:
+
+- `ADMIN_USERNAME` – username for the admin login (defaults to `admin`)
+- `ADMIN_PASSWORD` – password for the admin login (defaults to `password`)
+- `SESSION_SECRET` – secret used to sign session cookies (defaults to `gallerysecret`)
+
+Set these variables before starting the server to override the defaults.
+
 ## Gallery pages
 
 Navigating to `/demo-gallery` or another gallery slug will display a public gallery page rendered from placeholder data.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,12 @@ const session = require('express-session');
 const bodyParser = require('body-parser');
 const path = require('path');
 
+// Read credentials and session secret from environment variables with
+// development-friendly defaults
+const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
+const SESSION_SECRET = process.env.SESSION_SECRET || 'gallerysecret';
+
 const app = express();
 
 app.set('view engine', 'ejs');
@@ -10,7 +16,7 @@ app.set('views', path.join(__dirname, 'views'));
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(session({ secret: 'gallerysecret', resave: false, saveUninitialized: true }));
+app.use(session({ secret: SESSION_SECRET, resave: false, saveUninitialized: true }));
 
 // Placeholder data stored in-memory
 const galleries = [
@@ -140,7 +146,7 @@ app.get('/login', (req, res) => {
 
 app.post('/login', (req, res) => {
   const { username, password } = req.body;
-  if (username === 'admin' && password === 'password') {
+  if (username === ADMIN_USERNAME && password === ADMIN_PASSWORD) {
     req.session.user = username;
     return res.redirect('/dashboard');
   }


### PR DESCRIPTION
## Summary
- move admin credentials and session secret to env vars in server.js
- document environment variables in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d4a29caa483209166c768ca635184