### PR TITLE
Add persistent session store with MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm start
 
 After running the server, visit `http://localhost:3000` in your browser to view the homepage.
 
+### Persistent sessions
+
+Sessions are stored in MongoDB using `connect-mongo`. Provide a MongoDB
+connection string via the `MONGODB_URI` environment variable before starting the
+server. By default the app connects to `mongodb://localhost:27017/fineartsuite`.
+
 ## Gallery pages
 
 Navigating to `/demo-gallery` or another gallery slug will display a public gallery page rendered from placeholder data.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.18.2",
     "ejs": "^3.1.9",
     "express-session": "^1.17.3",
-    "body-parser": "^1.20.2"
+    "body-parser": "^1.20.2",
+    "connect-mongo": "^4.6.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const session = require('express-session');
+const MongoStore = require('connect-mongo');
 const bodyParser = require('body-parser');
 const path = require('path');
 
@@ -10,7 +11,18 @@ app.set('views', path.join(__dirname, 'views'));
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(session({ secret: 'gallerysecret', resave: false, saveUninitialized: true }));
+
+const sessionStore = MongoStore.create({
+  mongoUrl: process.env.MONGODB_URI || 'mongodb://localhost:27017/fineartsuite',
+  collectionName: 'sessions'
+});
+
+app.use(session({
+  secret: 'gallerysecret',
+  resave: false,
+  saveUninitialized: false,
+  store: sessionStore
+}));
 
 // Placeholder data stored in-memory
 const galleries = [


### PR DESCRIPTION
## Summary
- use MongoDB-backed session store via connect-mongo
- document environment variable and setup steps
- declare connect-mongo dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d4a2fef4483208d44809db8404324