### PR TITLE
Add SQLite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ FineArtSuite is a minimal gallery website project. This repository provides a si
 
 ## Running the site locally
 
-The project now includes a small Node.js/Express application. Install dependencies and start the server:
+The project now includes a small Node.js/Express application with SQLite persistence. Install dependencies and start the server:
 
 ```bash
 npm install
 npm start
 ```
+
+On first run the application will create a `gallery.db` SQLite file in the project
+root populated with demo data. Remove this file if you want to start with an
+empty database.
 
 After running the server, visit `http://localhost:3000` in your browser to view the homepage.
 
@@ -25,7 +29,7 @@ Set these variables before starting the server to override the defaults.
 
 ## Gallery pages
 
-Navigating to `/demo-gallery` or another gallery slug will display a public gallery page rendered from placeholder data.
+Navigating to `/demo-gallery` or another gallery slug will display a public gallery page. Gallery, artist and artwork data is loaded from the SQLite database.
 
 ## Planned gallery features
 

--- a/models/artistModel.js
+++ b/models/artistModel.js
@@ -1,0 +1,14 @@
+const { db } = require('./db');
+
+function getArtist(gallerySlug, id, cb) {
+  db.get('SELECT * FROM artists WHERE id = ? AND gallery_slug = ?', [id, gallerySlug], (err, artist) => {
+    if (err || !artist) return cb(err || new Error('Not found'));
+    db.all('SELECT * FROM artworks WHERE artist_id = ?', [id], (err2, artworks) => {
+      if (err2) return cb(err2);
+      artist.artworks = artworks || [];
+      cb(null, artist);
+    });
+  });
+}
+
+module.exports = { getArtist };

--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -1,0 +1,21 @@
+const { db } = require('./db');
+
+function getArtwork(gallerySlug, id, cb) {
+  const query = `SELECT artworks.*, artists.gallery_slug, artists.id as artistId
+                 FROM artworks JOIN artists ON artworks.artist_id = artists.id
+                 WHERE artworks.id = ? AND artists.gallery_slug = ?`;
+  db.get(query, [id, gallerySlug], (err, row) => {
+    if (err || !row) return cb(err || new Error('Not found'));
+    const artwork = {
+      id: row.id,
+      title: row.title,
+      medium: row.medium,
+      dimensions: row.dimensions,
+      price: row.price,
+      image: row.image
+    };
+    cb(null, { artwork, artistId: row.artistId });
+  });
+}
+
+module.exports = { getArtwork };

--- a/models/db.js
+++ b/models/db.js
@@ -1,0 +1,56 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const db = new sqlite3.Database(path.join(__dirname, '..', 'gallery.db'));
+
+function initialize() {
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS galleries (
+      slug TEXT PRIMARY KEY,
+      name TEXT,
+      bio TEXT
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS artists (
+      id TEXT PRIMARY KEY,
+      gallery_slug TEXT,
+      name TEXT,
+      bio TEXT
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS artworks (
+      id TEXT PRIMARY KEY,
+      artist_id TEXT,
+      title TEXT,
+      medium TEXT,
+      dimensions TEXT,
+      price TEXT,
+      image TEXT
+    )`);
+
+    db.get('SELECT COUNT(*) as count FROM galleries', (err, row) => {
+      if (err) return;
+      if (row.count === 0) seed();
+    });
+  });
+}
+
+function seed() {
+  const galleryStmt = db.prepare('INSERT INTO galleries (slug, name, bio) VALUES (?,?,?)');
+  galleryStmt.run('demo-gallery', 'Demo Gallery', 'Welcome to the demo gallery showcasing placeholder artwork.');
+  galleryStmt.run('city-gallery', 'City Gallery', 'Featuring modern works from local artists.');
+  galleryStmt.finalize();
+
+  const artistStmt = db.prepare('INSERT INTO artists (id, gallery_slug, name, bio) VALUES (?,?,?,?)');
+  artistStmt.run('artist1', 'demo-gallery', 'Jane Doe', 'An abstract artist exploring color and form.');
+  artistStmt.run('artist2', 'city-gallery', 'John Smith', 'Exploring the geometry of urban life.');
+  artistStmt.finalize();
+
+  const artworkStmt = db.prepare('INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, image) VALUES (?,?,?,?,?,?,?)');
+  artworkStmt.run('art1', 'artist1', 'Dreamscape', 'Oil on Canvas', '30x40', '$4000', 'https://placehold.co/600x400?text=Dreamscape');
+  artworkStmt.run('art2', 'artist1', 'Ocean Depths', 'Acrylic', '24x36', '$2500', 'https://placehold.co/600x400?text=Ocean+Depths');
+  artworkStmt.run('c1', 'artist2', 'City Lights', 'Oil on Canvas', '24x30', '$3500', 'https://via.placeholder.com/600x400?text=City+Lights');
+  artworkStmt.finalize();
+}
+
+module.exports = { db, initialize };

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -1,0 +1,27 @@
+const { db } = require('./db');
+
+function getGallery(slug, cb) {
+  const galleryQuery = 'SELECT slug, name, bio FROM galleries WHERE slug = ?';
+  db.get(galleryQuery, [slug], (err, gallery) => {
+    if (err || !gallery) return cb(err || new Error('Not found'));
+    db.all('SELECT * FROM artists WHERE gallery_slug = ?', [slug], (err2, artists) => {
+      if (err2) return cb(err2);
+      let remaining = artists.length;
+      if (remaining === 0) {
+        gallery.artists = [];
+        return cb(null, gallery);
+      }
+      artists.forEach(artist => {
+        db.all('SELECT * FROM artworks WHERE artist_id = ?', [artist.id], (err3, artworks) => {
+          artist.artworks = artworks || [];
+          if (--remaining === 0) {
+            gallery.artists = artists;
+            cb(null, gallery);
+          }
+        });
+      });
+    });
+  });
+}
+
+module.exports = { getGallery };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.18.2",
     "ejs": "^3.1.9",
     "express-session": "^1.17.3",
-    "body-parser": "^1.20.2"
+    "body-parser": "^1.20.2",
+    "sqlite3": "^5.1.6"
   }
 }


### PR DESCRIPTION
## Summary
- add sqlite3 dependency
- store galleries, artists, and artworks in SQLite using simple models
- read data from the database in Express routes
- update documentation with database info

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d4b62dec48320bea2af7ff0f91157