### PR TITLE
feat: implement artwork upload

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,0 +1,27 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const dbPath = path.join(__dirname, 'data', 'db.json');
+
+async function loadDB() {
+  try {
+    const data = await fs.readFile(dbPath, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    if (err.code === 'ENOENT') return { artworks: [] };
+    throw err;
+  }
+}
+
+async function saveDB(db) {
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+  await fs.writeFile(dbPath, JSON.stringify(db, null, 2));
+}
+
+async function addArtwork(artwork) {
+  const db = await loadDB();
+  db.artworks.push(artwork);
+  await saveDB(db);
+}
+
+module.exports = { loadDB, saveDB, addArtwork };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.18.2",
     "ejs": "^3.1.9",
     "express-session": "^1.17.3",
-    "body-parser": "^1.20.2"
+    "body-parser": "^1.20.2",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -57,7 +57,13 @@
 <body>
   <div class="container">
     <h1>Upload Artwork</h1>
-    <form id="upload-form">
+    <% if (message) { %>
+      <p style="color: green"><%= message %></p>
+    <% } %>
+    <% if (error) { %>
+      <p style="color: red"><%= error %></p>
+    <% } %>
+    <form id="upload-form" method="POST" action="/dashboard/upload" enctype="multipart/form-data">
       <label for="title">Title</label>
       <input type="text" id="title" name="title" required>
 


### PR DESCRIPTION
## Summary
- add basic JSON database layer for storing uploaded artwork
- configure multer for image uploads and implement POST `/dashboard/upload`
- show upload feedback in admin template and submit the form to new route
- include multer dependency in `package.json`

## Testing
- `npm test` *(fails: no test specified)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/multer)*
- `node server.js` *(fails: Cannot find module 'multer')*

------
https://chatgpt.com/codex/tasks/task_e_688d4b9d13388320a516a37304c4648f