### PR TITLE
Add route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ The current page is only a basic landing page. Future improvements may include:
 ## Admin upload page
 
 An `admin-upload.html` file is available for uploading new artwork. It provides fields for title, medium, dimensions, price, image upload with preview, and status. Open the file in a browser to use the form.
+
+## Running tests
+
+The project uses Node's built-in `test` runner for basic route tests. After installing dependencies, run:
+
+```bash
+npm test
+```
+
+This will start the application in test mode and verify that the homepage and a sample gallery page respond correctly.

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -16,6 +16,10 @@ function getGallery(slug, cb) {
           artist.artworks = artworks || [];
           if (--remaining === 0) {
             gallery.artists = artists;
+            const firstArtist = artists[0];
+            if (firstArtist && firstArtist.artworks && firstArtist.artworks[0]) {
+              gallery.featuredArtwork = firstArtist.artworks[0];
+            }
             cb(null, gallery);
           }
         });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "FineArtSuite is a minimal gallery website project. This repository provides a single HTML file that serves as a starting point for displaying art online.",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/server.js
+++ b/server.js
@@ -114,4 +114,9 @@ app.get('/dashboard/settings', requireLogin, (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+
+if (require.main === module) {
+  app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+}
+
+module.exports = app;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const app = require('../server');
+
+let server;
+
+// Start server before tests
+test.before(async () => {
+  server = await new Promise(resolve => {
+    const s = app.listen(0, () => resolve(s));
+  });
+});
+
+// Close server after tests
+test.after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, res => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+    }).on('error', reject);
+  });
+}
+
+test('homepage responds with welcome text', async () => {
+  const port = server.address().port;
+  const { statusCode, body } = await httpGet(`http://localhost:${port}/`);
+  assert.strictEqual(statusCode, 200);
+  assert.match(body, /FineArt Gallery Platform/);
+});
+
+test('gallery page responds with gallery name', async () => {
+  const port = server.address().port;
+  const { statusCode, body } = await httpGet(`http://localhost:${port}/demo-gallery`);
+  assert.strictEqual(statusCode, 200);
+  assert.match(body, /Demo Gallery/);
+});


### PR DESCRIPTION
## Summary
- export `app` from server so it can be tested
- set a featured artwork when loading gallery data
- add Node test script in `package.json`
- document the new test command in the README
- add basic tests for home and gallery routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d4c64d5f88320b470f56a8f38416b