### PR TITLE
feat: improve authentication security

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The server reads credentials and session configuration from environment variable
 - `ADMIN_USERNAME` – username for the admin login (defaults to `admin`)
 - `ADMIN_PASSWORD` – password for the admin login (defaults to `password`)
 - `SESSION_SECRET` – secret used to sign session cookies (defaults to `gallerysecret`)
+- `ADMIN_PASSWORD_SALT` – salt used for hashing the admin password (defaults to `staticSalt`)
 
 Set these variables before starting the server to override the defaults.
 
@@ -43,3 +44,7 @@ The current page is only a basic landing page. Future improvements may include:
 ## Admin upload page
 
 An `admin-upload.html` file is available for uploading new artwork. It provides fields for title, medium, dimensions, price, image upload with preview, and status. Open the file in a browser to use the form.
+
+## Security features
+
+The server now hashes the configured admin password using Node's `crypto.scrypt` before comparison. All form submissions include a CSRF token stored in the user session. Basic validation is applied to the login and upload forms to reject missing or malformed fields.

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -57,7 +57,8 @@
 <body>
   <div class="container">
     <h1>Upload Artwork</h1>
-    <form id="upload-form">
+    <form id="upload-form" method="POST" action="/dashboard/upload" enctype="multipart/form-data">
+      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <label for="title">Title</label>
       <input type="text" id="title" name="title" required>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -8,6 +8,7 @@
   <h1>Login</h1>
   <% if (error) { %><p style="color:red"><%= error %></p><% } %>
   <form method="POST" action="/login">
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <label>Username <input type="text" name="username"></label><br>
     <label>Password <input type="password" name="password"></label><br>
     <button type="submit">Login</button>


### PR DESCRIPTION
## Summary
- hash admin password with crypto scrypt
- add custom CSRF middleware and expose token to views
- validate login and upload forms
- mention new security features in README

## Testing
- `node --check server.js`
- `node server.js &` *(started server)*

------
https://chatgpt.com/codex/tasks/task_e_688d4c67b6008320a79c47000bba4a12