### PR TITLE
Add 404 page

### DIFF
--- a/server.js
+++ b/server.js
@@ -113,5 +113,10 @@ app.get('/dashboard/settings', requireLogin, (req, res) => {
   res.render('admin/settings');
 });
 
+// Render custom 404 page for any unmatched routes
+app.use((req, res) => {
+  res.status(404).render('404');
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Page Not Found</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <h1>404 - Page Not Found</h1>
+  <p>The page you are looking for doesn't exist.</p>
+  <p><a href="/">Return to home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show `404` page when a route isn't found
- render new `views/404.ejs` template

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d4c775e38832087f3274892fc4eec