### PR TITLE
Guard demo auth with env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ The server reads credentials and session configuration from environment variable
 - `ADMIN_USERNAME` – username for the admin login (defaults to `admin`)
 - `ADMIN_PASSWORD` – password for the admin login (defaults to `password`)
 - `SESSION_SECRET` – secret used to sign session cookies (defaults to `gallerysecret`)
+- `USE_DEMO_AUTH` – set to `true` to automatically log into admin pages
 
 Set these variables before starting the server to override the defaults.
+
+When `USE_DEMO_AUTH` is disabled (the default), all `/dashboard` routes require
+logging in. Set the variable to `true` during development to bypass the login
+form for convenience.
 
 ## Gallery pages
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,3 +1,4 @@
+process.env.USE_DEMO_AUTH = 'false';
 const test = require('node:test');
 const assert = require('node:assert');
 const http = require('node:http');
@@ -22,7 +23,7 @@ function httpGet(url) {
     http.get(url, res => {
       let body = '';
       res.on('data', chunk => body += chunk);
-      res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+      res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
     }).on('error', reject);
   });
 }
@@ -39,4 +40,18 @@ test('gallery page responds with gallery name', async () => {
   const { statusCode, body } = await httpGet(`http://localhost:${port}/demo-gallery`);
   assert.strictEqual(statusCode, 200);
   assert.match(body, /Demo Gallery/);
+});
+
+test('dashboard redirects to login when not authenticated', async () => {
+  const port = server.address().port;
+  const { statusCode, headers } = await httpGet(`http://localhost:${port}/dashboard`);
+  assert.strictEqual(statusCode, 302);
+  assert.strictEqual(headers.location, '/login');
+});
+
+test('upload page redirects to login when not authenticated', async () => {
+  const port = server.address().port;
+  const { statusCode, headers } = await httpGet(`http://localhost:${port}/dashboard/upload`);
+  assert.strictEqual(statusCode, 302);
+  assert.strictEqual(headers.location, '/login');
 });


### PR DESCRIPTION
## Summary
- add `USE_DEMO_AUTH` flag in `server.js`
- document `USE_DEMO_AUTH` in README
- update admin routing order so /dashboard isn't mistaken for a gallery
- test that admin pages redirect to login when demo auth is disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5255c1608320a3c9dddd82d30f36