### PR TITLE
Improve error handling with flash messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ When `USE_DEMO_AUTH` is disabled (the default), all `/dashboard` routes require
 logging in. Set the variable to `true` during development to bypass the login
 form for convenience.
 
+The application uses simple flash messages stored in the session to display
+login errors and form validation feedback.
+
 ## Gallery pages
 
 Navigating to `/demo-gallery` or another gallery slug will display a public gallery page. Gallery, artist and artwork data is loaded from the SQLite database.

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -129,8 +129,8 @@ test('login fails with bad credentials', async () => {
     username: 'admin',
     password: 'wrong'
   });
-  assert.strictEqual(res.statusCode, 200);
-  assert.match(res.body, /Invalid credentials/);
+  assert.strictEqual(res.statusCode, 302);
+  assert.strictEqual(res.headers.location, '/login');
 });
 
 test('logout destroys session', async () => {

--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -6,6 +6,12 @@
 </head>
 <body>
   <h1>Artist Management</h1>
+  <% if (flash.error && flash.error.length) { %>
+    <p style="color:red"><%= flash.error[0] %></p>
+  <% } %>
+  <% if (flash.success && flash.success.length) { %>
+    <p style="color:green"><%= flash.success[0] %></p>
+  <% } %>
   <form id="add-artist" method="post" action="/dashboard/artists">
     <label>ID <input type="text" name="id" required></label><br>
     <label>Gallery Slug <input type="text" name="gallery_slug" required></label><br>

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -6,6 +6,12 @@
 </head>
 <body>
   <h1>Artwork Management</h1>
+  <% if (flash.error && flash.error.length) { %>
+    <p style="color:red"><%= flash.error[0] %></p>
+  <% } %>
+  <% if (flash.success && flash.success.length) { %>
+    <p style="color:green"><%= flash.success[0] %></p>
+  <% } %>
   <form id="add-art" method="post" action="/dashboard/artworks">
     <label>ID <input type="text" name="id" required></label><br>
     <label>Artist ID <input type="text" name="artist_id" required></label><br>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -6,7 +6,9 @@
 </head>
 <body>
   <h1>Login</h1>
-  <% if (error) { %><p style="color:red"><%= error %></p><% } %>
+  <% if (flash.error && flash.error.length) { %>
+    <p style="color:red"><%= flash.error[0] %></p>
+  <% } %>
   <form method="POST" action="/login">
     <label>Username <input type="text" name="username"></label><br>
     <label>Password <input type="password" name="password"></label><br>


### PR DESCRIPTION
## Summary
- implement simple session-based flash messaging
- wrap db queries in try/catch blocks
- show flash messages for login and admin forms
- update tests for new login flow
- document flash messaging in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5a205bb48320b005aedef78fd455