### PR TITLE
Implement basic image upload handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ejs": "^3.1.9",
     "express-session": "^1.17.3",
     "body-parser": "^1.20.2",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -52,7 +52,10 @@
 <body>
   <div class="container">
     <h1>Upload Artwork</h1>
-    <form id="upload-form">
+    <% if (success) { %>
+      <p id="status">Upload successful!</p>
+    <% } %>
+    <form id="upload-form" method="post" action="/dashboard/upload" enctype="multipart/form-data">
       <label for="title">Title</label>
       <input type="text" id="title" name="title" required>
 
@@ -77,6 +80,15 @@
 
       <button type="submit">Submit</button>
     </form>
+    <h2>Uploaded Files</h2>
+    <ul>
+      <% files.forEach(function(f) { %>
+        <li>
+          <img src="<%= f.url %>" alt="<%= f.name %>" style="max-width:100px;">
+          <span><%= f.name %></span>
+        </li>
+      <% }) %>
+    </ul>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- add `multer` dependency and create uploads folder
- initialize `multer` in server and create upload route
- list uploaded images in admin panel with preview

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find module 'multer')*

------
https://chatgpt.com/codex/tasks/task_e_688d5a5575bc83209af077289919c3fd