### PR TITLE
Add login flash for admin auth

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,6 +37,7 @@ function simulateAuth(req, res, next) {
 
 function requireLogin(req, res, next) {
   if (req.session.user) return next();
+  req.session.flash = 'Please log in to continue';
   res.redirect('/login');
 }
 
@@ -47,7 +48,9 @@ app.get('/', (req, res) => {
 
 // Auth routes
 app.get('/login', (req, res) => {
-  res.render('login', { error: null });
+  const flash = req.session.flash;
+  delete req.session.flash;
+  res.render('login', { error: null, flash });
 });
 
 app.post('/login', (req, res) => {
@@ -56,7 +59,7 @@ app.post('/login', (req, res) => {
     req.session.user = username;
     return res.redirect('/dashboard');
   }
-  res.render('login', { error: 'Invalid credentials' });
+  res.render('login', { error: 'Invalid credentials', flash: null });
 });
 
 app.get('/logout', (req, res) => {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -109,6 +109,14 @@ test('upload page redirects to login when not authenticated', async () => {
   assert.strictEqual(headers.location, '/login');
 });
 
+test('login page shows flash after unauthorized access', async () => {
+  const port = server.address().port;
+  const res = await httpGet(`http://localhost:${port}/dashboard`);
+  const cookie = res.headers['set-cookie'][0].split(';')[0];
+  const login = await httpRequest('GET', `http://localhost:${port}/login`, null, cookie);
+  assert.match(login.body, /Please log in to continue/);
+});
+
 test('login succeeds with correct credentials', async () => {
   const port = server.address().port;
   const res = await httpPostForm(`http://localhost:${port}/login`, {

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -6,6 +6,7 @@
 </head>
 <body>
   <h1>Login</h1>
+  <% if (flash) { %><p style="color:red"><%= flash %></p><% } %>
   <% if (error) { %><p style="color:red"><%= error %></p><% } %>
   <form method="POST" action="/login">
     <label>Username <input type="text" name="username"></label><br>


### PR DESCRIPTION
## Summary
- introduce `requireLogin` middleware that sets a flash message
- display flash message on login page
- test flash behaviour when accessing protected pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5acddb908320a2d02a44f7fb8714