### PR TITLE
Add Render deployment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ npm test
 
 This will start the application in test mode and verify that the homepage and a sample gallery page respond correctly.
 
+## Deployment on Render
+
+The repository includes a `render.yaml` file for deploying the app to
+[Render](https://render.com). Create a new Web Service using this repository
+and Render will apply the provided build and start commands. The configuration
+sets default environment variables and mounts a small persistent disk for the
+SQLite database.
+
 ## License
 
 FineArtSuite is released under the [ISC License](LICENSE).

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  - type: web
+    name: fineartsuite
+    env: node
+    branch: main
+    buildCommand: npm install
+    startCommand: npm start
+    plan: free
+    runtime: node
+    envVars:
+      - key: ADMIN_USERNAME
+        value: admin
+      - key: ADMIN_PASSWORD
+        value: password
+      - key: SESSION_SECRET
+        value: gallerysecret
+      - key: USE_DEMO_AUTH
+        value: true
+    disk:
+      name: gallerydb
+      mountPath: /opt/render/project/src
+      sizeGB: 1


### PR DESCRIPTION
## Summary
- add `render.yaml` for Render deployment
- document Render deployment instructions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5e67a0b88320a441c9e9cf23f9a7