### PR TITLE
Add CSRF protection

### DIFF
--- a/middleware/csrf.js
+++ b/middleware/csrf.js
@@ -1,0 +1,27 @@
+const crypto = require('node:crypto');
+
+function csrf() {
+  return function(req, res, next) {
+    if (!req.session) {
+      throw new Error('CSRF protection requires session');
+    }
+    if (!req.session.csrfSecret) {
+      req.session.csrfSecret = crypto.randomBytes(16).toString('hex');
+    }
+    req.csrfToken = function() {
+      return crypto.createHmac('sha256', req.session.csrfSecret).update('token').digest('hex');
+    };
+    if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) {
+      return next();
+    }
+    const token = req.body?._csrf || req.headers['csrf-token'] || req.query._csrf;
+    if (token !== req.csrfToken()) {
+      const err = new Error('invalid csrf token');
+      err.code = 'EBADCSRFTOKEN';
+      return next(err);
+    }
+    next();
+  };
+}
+
+module.exports = csrf;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -6,6 +6,13 @@ const querystring = require('node:querystring');
 const app = require('../server');
 const { db } = require('../models/db');
 
+function extractCsrfToken(html) {
+  const match = html.match(/name="_csrf" value="([^"]+)"/);
+  if (match) return match[1];
+  const meta = html.match(/<meta name="csrf-token" content="([^"]+)"/);
+  return meta ? meta[1] : null;
+}
+
 let server;
 
 // Start server before tests
@@ -24,30 +31,22 @@ test.after(async () => {
   await new Promise(resolve => server.close(resolve));
 });
 
-function httpGet(url) {
-  return new Promise((resolve, reject) => {
-    http.get(url, res => {
-      let body = '';
-      res.on('data', chunk => body += chunk);
-      res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
-    }).on('error', reject);
-  });
-}
-
-function httpRequest(method, url, data = null, cookies = '') {
+function httpRequest(method, url, data = null, cookies = '', csrfToken = '') {
   return new Promise((resolve, reject) => {
     const parsed = new URL(url);
     const payload = data ? JSON.stringify(data) : null;
+    const headers = {
+      'Content-Type': 'application/json',
+      'Content-Length': payload ? Buffer.byteLength(payload) : 0,
+      'Cookie': cookies
+    };
+    if (csrfToken) headers['CSRF-Token'] = csrfToken;
     const options = {
       method,
       hostname: parsed.hostname,
       port: parsed.port,
       path: parsed.pathname + (parsed.search || ''),
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': payload ? Buffer.byteLength(payload) : 0,
-        'Cookie': cookies
-      }
+      headers
     };
     const req = http.request(options, res => {
       let body = '';
@@ -58,6 +57,10 @@ function httpRequest(method, url, data = null, cookies = '') {
     if (payload) req.write(payload);
     req.end();
   });
+}
+
+function httpGet(url, cookies = '') {
+  return httpRequest('GET', url, null, cookies);
 }
 
 function httpPostForm(url, data, cookies = '') {
@@ -114,37 +117,62 @@ test('upload page redirects to login when not authenticated', async () => {
   assert.strictEqual(headers.location, '/login');
 });
 
-test('login succeeds with correct credentials', async () => {
+test('login rejects requests without CSRF token', async () => {
   const port = server.address().port;
   const res = await httpPostForm(`http://localhost:${port}/login`, {
     username: 'admin',
     password: 'password'
   });
+  assert.strictEqual(res.statusCode, 403);
+});
+
+test('login succeeds with correct credentials', async () => {
+  const port = server.address().port;
+  const page = await httpGet(`http://localhost:${port}/login`);
+  const csrf = extractCsrfToken(page.body);
+  const cookie = page.headers['set-cookie'][0].split(';')[0];
+  const res = await httpPostForm(`http://localhost:${port}/login`, {
+    username: 'admin',
+    password: 'password',
+    _csrf: csrf
+  }, cookie);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/dashboard');
-  assert.ok(res.headers['set-cookie']);
-  const cookie = res.headers['set-cookie'][0].split(';')[0];
-  const dash = await httpRequest('GET', `http://localhost:${port}/dashboard`, null, cookie);
+  let authCookie = cookie;
+  if (res.headers['set-cookie']) {
+    authCookie = res.headers['set-cookie'][0].split(';')[0];
+  }
+  const dash = await httpRequest('GET', `http://localhost:${port}/dashboard`, null, authCookie);
   assert.strictEqual(dash.statusCode, 200);
 });
 
 test('login fails with bad credentials', async () => {
   const port = server.address().port;
+  const page = await httpGet(`http://localhost:${port}/login`);
+  const csrf = extractCsrfToken(page.body);
+  const cookie = page.headers['set-cookie'][0].split(';')[0];
   const res = await httpPostForm(`http://localhost:${port}/login`, {
     username: 'admin',
-    password: 'wrong'
-  });
+    password: 'wrong',
+    _csrf: csrf
+  }, cookie);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
 });
 
 test('logout destroys session', async () => {
   const port = server.address().port;
+  const page = await httpGet(`http://localhost:${port}/login`);
+  const csrf = extractCsrfToken(page.body);
+  let cookie = page.headers['set-cookie'][0].split(';')[0];
   const login = await httpPostForm(`http://localhost:${port}/login`, {
     username: 'admin',
-    password: 'password'
-  });
-  const cookie = login.headers['set-cookie'][0].split(';')[0];
+    password: 'password',
+    _csrf: csrf
+  }, cookie);
+  if (login.headers['set-cookie']) {
+    cookie = login.headers['set-cookie'][0].split(';')[0];
+  }
   const out = await httpRequest('GET', `http://localhost:${port}/logout`, null, cookie);
   assert.strictEqual(out.statusCode, 302);
   assert.strictEqual(out.headers.location, '/login');
@@ -155,30 +183,46 @@ test('logout destroys session', async () => {
 
 test('admin artist routes allow CRUD after login', async () => {
   const port = server.address().port;
-  const login = await httpPostForm(`http://localhost:${port}/login`, { username: 'admin', password: 'password' });
-  const cookie = login.headers['set-cookie'][0].split(';')[0];
+  const loginPage = await httpGet(`http://localhost:${port}/login`);
+  const loginCsrf = extractCsrfToken(loginPage.body);
+  let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
+  const login = await httpPostForm(`http://localhost:${port}/login`, { username: 'admin', password: 'password', _csrf: loginCsrf }, cookie);
+  if (login.headers['set-cookie']) {
+    cookie = login.headers['set-cookie'][0].split(';')[0];
+  }
+
+  const page = await httpGet(`http://localhost:${port}/dashboard/artists`, cookie);
+  const token = extractCsrfToken(page.body);
 
   const id = `testartist${Date.now()}`;
-  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id, gallery_slug: 'demo-gallery', name: 'Tester', bio: 'Bio' }, cookie);
+  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id, gallery_slug: 'demo-gallery', name: 'Tester', bio: 'Bio', _csrf: token }, cookie);
   assert.strictEqual(res.statusCode, 302);
 
   res = await httpGet(`http://localhost:${port}/demo-gallery/artists/${id}`);
   assert.strictEqual(res.statusCode, 200);
   assert.match(res.body, /Tester/);
 
-  await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/${id}`, { name: 'Edited', bio: 'Bio' }, cookie);
+  await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/${id}`, { name: 'Edited', bio: 'Bio' }, cookie, token);
   res = await httpGet(`http://localhost:${port}/demo-gallery/artists/${id}`);
   assert.match(res.body, /Edited/);
 
-  await httpRequest('DELETE', `http://localhost:${port}/dashboard/artists/${id}`, null, cookie);
+  await httpRequest('DELETE', `http://localhost:${port}/dashboard/artists/${id}`, null, cookie, token);
   res = await httpGet(`http://localhost:${port}/demo-gallery/artists/${id}`);
   assert.strictEqual(res.statusCode, 404);
 });
 
 test('admin artwork routes allow CRUD after login', async () => {
   const port = server.address().port;
-  const login = await httpPostForm(`http://localhost:${port}/login`, { username: 'admin', password: 'password' });
-  const cookie = login.headers['set-cookie'][0].split(';')[0];
+  const loginPage = await httpGet(`http://localhost:${port}/login`);
+  const loginCsrf = extractCsrfToken(loginPage.body);
+  let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
+  const login = await httpPostForm(`http://localhost:${port}/login`, { username: 'admin', password: 'password', _csrf: loginCsrf }, cookie);
+  if (login.headers['set-cookie']) {
+    cookie = login.headers['set-cookie'][0].split(';')[0];
+  }
+
+  const artPage = await httpGet(`http://localhost:${port}/dashboard/artworks`, cookie);
+  const token = extractCsrfToken(artPage.body);
 
   const id = `testartwork${Date.now()}`;
   let res = await httpPostForm(`http://localhost:${port}/dashboard/artworks`, {
@@ -188,7 +232,8 @@ test('admin artwork routes allow CRUD after login', async () => {
     medium: 'Oil',
     dimensions: '1x1',
     price: '$1',
-    image: 'http://example.com'
+    image: 'http://example.com',
+    _csrf: token
   }, cookie);
   assert.strictEqual(res.statusCode, 302);
 
@@ -202,11 +247,11 @@ test('admin artwork routes allow CRUD after login', async () => {
     dimensions: '2x2',
     price: '$2',
     image: 'http://example.com/2'
-  }, cookie);
+  }, cookie, token);
   res = await httpGet(`http://localhost:${port}/demo-gallery/artworks/${id}`);
   assert.match(res.body, /UpdatedArt/);
 
-  await httpRequest('DELETE', `http://localhost:${port}/dashboard/artworks/${id}`, null, cookie);
+  await httpRequest('DELETE', `http://localhost:${port}/dashboard/artworks/${id}`, null, cookie, token);
   res = await httpGet(`http://localhost:${port}/demo-gallery/artworks/${id}`);
   assert.strictEqual(res.statusCode, 404);
 });
@@ -215,7 +260,7 @@ test('admin artwork routes allow CRUD after login', async () => {
 const fs = require('node:fs');
 const path = require('node:path');
 
-function httpPostMultipart(url, fields, filePath, cookies = '') {
+function httpPostMultipart(url, fields, filePath, cookies = '', csrfToken = '') {
   return new Promise((resolve, reject) => {
     const boundary = '----WebKitFormBoundary' + Math.random().toString(16);
     const parsed = new URL(url);
@@ -230,16 +275,18 @@ function httpPostMultipart(url, fields, filePath, cookies = '') {
     payloadParts.push(Buffer.from(`\r\n--${boundary}--\r\n`));
     const payload = Buffer.concat(payloadParts);
 
+    const headers = {
+      'Content-Type': 'multipart/form-data; boundary=' + boundary,
+      'Content-Length': payload.length,
+      'Cookie': cookies
+    };
+    if (csrfToken) headers['CSRF-Token'] = csrfToken;
     const options = {
       method: 'POST',
       hostname: parsed.hostname,
       port: parsed.port,
       path: parsed.pathname,
-      headers: {
-        'Content-Type': 'multipart/form-data; boundary=' + boundary,
-        'Content-Length': payload.length,
-        'Cookie': cookies
-      }
+      headers
     };
     const req = http.request(options, res => {
       let body = '';
@@ -262,23 +309,26 @@ test.before(() => {
 
 test('artist and artwork routes require login', async () => {
   const port = server.address().port;
-  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id: 'x', gallery_slug: 'demo-gallery', name: 'n', bio: 'b' });
+  const page = await httpGet(`http://localhost:${port}/login`);
+  const token = extractCsrfToken(page.body);
+  const cookie = page.headers['set-cookie'][0].split(';')[0];
+  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id: 'x', gallery_slug: 'demo-gallery', name: 'n', bio: 'b', _csrf: token }, cookie);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
-  res = await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/x`, { name: 'n', bio: 'b' });
+  res = await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/x`, { name: 'n', bio: 'b' }, cookie, token);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
-  res = await httpRequest('DELETE', `http://localhost:${port}/dashboard/artists/x`);
+  res = await httpRequest('DELETE', `http://localhost:${port}/dashboard/artists/x`, null, cookie, token);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
 
-  res = await httpPostForm(`http://localhost:${port}/dashboard/artworks`, { id: 'x', artist_id: 'artist1', title: 't', medium: 'm', dimensions: 'd', price: 'p', image: 'i' });
+  res = await httpPostForm(`http://localhost:${port}/dashboard/artworks`, { id: 'x', artist_id: 'artist1', title: 't', medium: 'm', dimensions: 'd', price: 'p', image: 'i', _csrf: token }, cookie);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
-  res = await httpRequest('PUT', `http://localhost:${port}/dashboard/artworks/x`, { title: 't' });
+  res = await httpRequest('PUT', `http://localhost:${port}/dashboard/artworks/x`, { title: 't' }, cookie, token);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
-  res = await httpRequest('DELETE', `http://localhost:${port}/dashboard/artworks/x`);
+  res = await httpRequest('DELETE', `http://localhost:${port}/dashboard/artworks/x`, null, cookie, token);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
 });
@@ -287,9 +337,12 @@ test('upload post requires login', async () => {
   const port = server.address().port;
   const temp = path.join(__dirname, 'temp.jpg');
   fs.writeFileSync(temp, 'data');
+  const page = await httpGet(`http://localhost:${port}/login`);
+  const token = extractCsrfToken(page.body);
+  const cookie = page.headers['set-cookie'][0].split(';')[0];
   const res = await httpPostMultipart(`http://localhost:${port}/dashboard/upload`, {
-    title: 't', medium: 'm', dimensions: 'd', price: '1', status: 'available'
-  }, temp);
+    title: 't', medium: 'm', dimensions: 'd', price: '1', status: 'available', _csrf: token
+  }, temp, cookie, token);
   fs.unlinkSync(temp);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
@@ -297,13 +350,20 @@ test('upload post requires login', async () => {
 
 test('authenticated upload stores file, DB entry, and is served', async () => {
   const port = server.address().port;
-  const login = await httpPostForm(`http://localhost:${port}/login`, { username: 'admin', password: 'password' });
-  const cookie = login.headers['set-cookie'][0].split(';')[0];
+  const loginPage = await httpGet(`http://localhost:${port}/login`);
+  const loginCsrf = extractCsrfToken(loginPage.body);
+  let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
+  const login = await httpPostForm(`http://localhost:${port}/login`, { username: 'admin', password: 'password', _csrf: loginCsrf }, cookie);
+  if (login.headers['set-cookie']) {
+    cookie = login.headers['set-cookie'][0].split(';')[0];
+  }
   const temp = path.join(__dirname, 'upload.jpg');
   fs.writeFileSync(temp, 'image');
+  const page = await httpGet(`http://localhost:${port}/dashboard/upload`, cookie);
+  const token = extractCsrfToken(page.body);
   const uploadRes = await httpPostMultipart(`http://localhost:${port}/dashboard/upload`, {
-    title: 't', medium: 'm', dimensions: 'd', price: '1', status: 'available'
-  }, temp, cookie);
+    title: 't', medium: 'm', dimensions: 'd', price: '1', status: 'available', _csrf: token
+  }, temp, cookie, token);
   fs.unlinkSync(temp);
   assert.strictEqual(uploadRes.statusCode, 302);
   assert.strictEqual(uploadRes.headers.location, '/dashboard/upload?success=1');

--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -3,6 +3,7 @@
 <head>
   <title>Manage Artists</title>
   <link rel="stylesheet" href="/styles.css">
+  <meta name="csrf-token" content="<%= csrfToken %>">
 </head>
 <body>
   <h1>Artist Management</h1>
@@ -17,6 +18,7 @@
     <label>Gallery Slug <input type="text" name="gallery_slug" required></label><br>
     <label>Name <input type="text" name="name" required></label><br>
     <label>Bio <input type="text" name="bio" required></label><br>
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <button type="submit">Add Artist</button>
   </form>
   <h2>Existing Artists</h2>
@@ -35,6 +37,7 @@
   </ul>
   <p><a href="/dashboard">Back to dashboard</a></p>
   <script>
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     document.querySelectorAll('.artist-form').forEach(f => {
       const id = f.dataset.id;
       f.addEventListener('submit', async e => {
@@ -42,14 +45,14 @@
         const data = Object.fromEntries(new FormData(f).entries());
         await fetch('/dashboard/artists/' + id, {
           method: 'PUT',
-          headers: {'Content-Type':'application/json'},
+          headers: {'Content-Type':'application/json', 'CSRF-Token': csrfToken},
           body: JSON.stringify(data)
         });
         location.reload();
       });
       f.querySelector('.delete').addEventListener('click', async e => {
         e.preventDefault();
-        await fetch('/dashboard/artists/' + id, { method: 'DELETE' });
+        await fetch('/dashboard/artists/' + id, { method: 'DELETE', headers: { 'CSRF-Token': csrfToken } });
         location.reload();
       });
     });

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -3,6 +3,7 @@
 <head>
   <title>Manage Artworks</title>
   <link rel="stylesheet" href="/styles.css">
+  <meta name="csrf-token" content="<%= csrfToken %>">
 </head>
 <body>
   <h1>Artwork Management</h1>
@@ -20,6 +21,7 @@
     <label>Dimensions <input type="text" name="dimensions" required></label><br>
     <label>Price <input type="text" name="price" required></label><br>
     <label>Image <input type="text" name="image" required></label><br>
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <button type="submit">Add Artwork</button>
   </form>
   <h2>Existing Artworks</h2>
@@ -41,6 +43,7 @@
   </ul>
   <p><a href="/dashboard">Back to dashboard</a></p>
   <script>
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     document.querySelectorAll('.art-form').forEach(f => {
       const id = f.dataset.id;
       f.addEventListener('submit', async e => {
@@ -48,14 +51,14 @@
         const data = Object.fromEntries(new FormData(f).entries());
         await fetch('/dashboard/artworks/' + id, {
           method: 'PUT',
-          headers: {'Content-Type':'application/json'},
+          headers: {'Content-Type':'application/json', 'CSRF-Token': csrfToken},
           body: JSON.stringify(data)
         });
         location.reload();
       });
       f.querySelector('.delete').addEventListener('click', async e => {
         e.preventDefault();
-        await fetch('/dashboard/artworks/' + id, { method: 'DELETE' });
+        await fetch('/dashboard/artworks/' + id, { method: 'DELETE', headers: { 'CSRF-Token': csrfToken } });
         location.reload();
       });
     });

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -77,7 +77,7 @@
         <option value="available">Available</option>
         <option value="sold">Sold</option>
       </select>
-
+      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <button type="submit">Submit</button>
     </form>
     <h2>Uploaded Files</h2>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -12,6 +12,7 @@
   <form method="POST" action="/login">
     <label>Username <input type="text" name="username"></label><br>
     <label>Password <input type="password" name="password"></label><br>
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <button type="submit">Login</button>
   </form>
   <p><a href="/">Back home</a></p>


### PR DESCRIPTION
## Summary
- add simple CSRF middleware and error handling
- include CSRF tokens in admin and login forms
- test that requests without a CSRF token are rejected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e04dbd3048320af0a4ee3b279d7b1