### PR TITLE
style public pages with tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,42 @@ After logging in you can upload new artwork at `/dashboard/upload`. The form
 provides fields for the artwork details along with an image preview before
 submitting.
 
+## Sample EJS snippets
+
+Styled navigation bar:
+
+```ejs
+<nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+  <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+  <div class="flex space-x-4 mt-2 md:mt-0">
+    <a href="/galleries" class="hover:underline">Galleries</a>
+    <a href="/artists" class="hover:underline">Artists</a>
+  </div>
+</nav>
+```
+
+Clean hero heading:
+
+```ejs
+<section class="text-center py-24">
+  <h1 class="text-5xl font-bold mb-6">Discover Modern Art</h1>
+  <p class="text-gray-600">Explore our curated collection.</p>
+</section>
+```
+
+Two-column layout of artwork thumbnails:
+
+```ejs
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+  <% artworks.forEach(art => { %>
+    <a href="/artworks/<%= art.id %>" class="block">
+      <img src="<%= art.image %>" alt="<%= art.title %>" class="w-full mb-2"/>
+      <h3 class="font-semibold"><%= art.title %></h3>
+    </a>
+  <% }) %>
+</div>
+```
+
 ## Running tests
 
 The project uses Node's built-in `test` runner for basic route tests. After installing dependencies, run:

--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -4,20 +4,41 @@
   <title><%= artist.name %> - <%= gallery.name %></title>
   <link rel="stylesheet" href="/css/main.css">
 </head>
-<body>
-  <h1><%= artist.name %></h1>
-  <p><%= artist.bio %></p>
-  <h2>Artworks</h2>
-  <ul>
-    <% artist.artworks.forEach(function(art){ %>
-      <li>
-        <a href="/<%= slug %>/artworks/<%= art.id %>">
-          <img src="<%= art.image %>" alt="<%= art.title %>" style="height:100px;">
-          <span><%= art.title %></span>
-        </a>
-      </li>
-    <% }) %>
-  </ul>
-  <p><a href="/<%= slug %>">Back to gallery</a></p>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex space-x-4 mt-2 md:mt-0">
+      <a href="/<%= slug %>" class="hover:underline">Gallery</a>
+    </div>
+  </nav>
+
+  <main class="max-w-4xl mx-auto p-6">
+    <header class="text-center mb-12">
+      <h1 class="text-4xl font-bold mb-4"><%= artist.name %></h1>
+      <p class="text-gray-600"><%= artist.bio %></p>
+    </header>
+
+    <section>
+      <h2 class="text-2xl font-bold mb-4">Artworks</h2>
+      <ul class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <% artist.artworks.forEach(function(art){ %>
+          <li>
+            <a href="/<%= slug %>/artworks/<%= art.id %>" class="block">
+              <img src="<%= art.image %>" alt="<%= art.title %>" class="w-full mb-2">
+              <span class="font-semibold"><%= art.title %></span>
+            </a>
+          </li>
+        <% }) %>
+      </ul>
+    </section>
+
+    <div class="mt-12 text-center">
+      <a class="underline" href="/<%= slug %>">Back to gallery</a>
+    </div>
+  </main>
+
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
 </body>
 </html>

--- a/views/artwork-detail.ejs
+++ b/views/artwork-detail.ejs
@@ -4,14 +4,37 @@
   <title><%= artwork.title %> - <%= gallery.name %></title>
   <link rel="stylesheet" href="/css/main.css">
 </head>
-<body>
-  <h1><%= artwork.title %></h1>
-  <img src="<%= artwork.image %>" alt="<%= artwork.title %>" style="max-width:400px;">
-  <ul>
-    <li>Medium: <%= artwork.medium %></li>
-    <li>Dimensions: <%= artwork.dimensions %></li>
-    <li>Price: <%= artwork.price %></li>
-  </ul>
-  <p><a href="/<%= slug %>/artists/<%= artistId %>">Back to artist</a></p>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex space-x-4 mt-2 md:mt-0">
+      <a href="/<%= slug %>" class="hover:underline">Gallery</a>
+      <a href="/<%= slug %>/artists/<%= artistId %>" class="hover:underline">Artist</a>
+    </div>
+  </nav>
+
+  <main class="max-w-3xl mx-auto p-6">
+    <header class="text-center mb-8">
+      <h1 class="text-4xl font-bold mb-4"><%= artwork.title %></h1>
+    </header>
+
+    <div class="mb-8">
+      <img src="<%= artwork.image %>" alt="<%= artwork.title %>" class="mx-auto max-w-full">
+    </div>
+
+    <ul class="max-w-md mx-auto divide-y divide-gray-200 text-center">
+      <li class="py-2">Medium: <span class="font-semibold"><%= artwork.medium %></span></li>
+      <li class="py-2">Dimensions: <span class="font-semibold"><%= artwork.dimensions %></span></li>
+      <li class="py-2">Price: <span class="font-semibold"><%= artwork.price %></span></li>
+    </ul>
+
+    <div class="mt-8 text-center">
+      <a class="underline" href="/<%= slug %>/artists/<%= artistId %>">Back to artist</a>
+    </div>
+  </main>
+
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
 </body>
 </html>

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -4,19 +4,46 @@
   <title><%= gallery.name %> - Gallery</title>
   <link rel="stylesheet" href="/css/main.css">
 </head>
-<body>
-  <h1><%= gallery.name %></h1>
-  <p><%= gallery.bio %></p>
-  <h2>Featured Artwork</h2>
-  <img src="<%= gallery.featuredArtwork.image %>" alt="<%= gallery.featuredArtwork.title %>" style="max-width:400px;">
-  <p><%= gallery.featuredArtwork.title %></p>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex space-x-4 mt-2 md:mt-0">
+      <a href="/" class="hover:underline">Home</a>
+    </div>
+  </nav>
 
-  <h2>Artists</h2>
-  <ul>
-    <% gallery.artists.forEach(function(artist){ %>
-      <li><a href="/<%= slug %>/artists/<%= artist.id %>"><%= artist.name %></a></li>
-    <% }) %>
-  </ul>
-  <p><a href="/">Back home</a></p>
+  <main class="max-w-4xl mx-auto p-6">
+    <header class="text-center mb-12">
+      <h1 class="text-4xl font-bold mb-4"><%= gallery.name %></h1>
+      <p class="text-gray-600"><%= gallery.bio %></p>
+    </header>
+
+    <section class="mb-12">
+      <h2 class="text-2xl font-bold mb-4">Featured Artwork</h2>
+      <div class="text-center">
+        <img src="<%= gallery.featuredArtwork.image %>" alt="<%= gallery.featuredArtwork.title %>" class="mx-auto max-w-sm">
+        <p class="mt-4 font-semibold"><%= gallery.featuredArtwork.title %></p>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="text-2xl font-bold mb-4">Artists</h2>
+      <ul class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <% gallery.artists.forEach(function(artist){ %>
+          <li>
+            <a class="block p-4 border border-gray-200 hover:bg-gray-50" href="/<%= slug %>/artists/<%= artist.id %>"><%= artist.name %></a>
+          </li>
+        <% }) %>
+      </ul>
+    </section>
+
+    <div class="mt-12 text-center">
+      <a class="underline" href="/">Back home</a>
+    </div>
+  </main>
+
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
 </body>
 </html>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -4,12 +4,24 @@
   <title>FineArt Gallery SaaS</title>
   <link rel="stylesheet" href="/css/main.css">
 </head>
-<body class="bg-gray-50">
-  <section class="text-center py-20">
-    <h1 class="text-5xl font-extrabold mb-4">FineArt Gallery Platform</h1>
-    <p class="text-lg text-gray-700 mb-8">Welcome to FineArtSuite, the easiest way to manage your online art gallery.</p>
-    <p><a class="text-blue-600 underline" href="/demo-gallery">View demo gallery</a></p>
-    <p><a class="text-blue-600 underline" href="/login">Admin Login</a></p>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex space-x-4 mt-2 md:mt-0">
+      <a href="/demo-gallery" class="hover:underline">Demo Gallery</a>
+      <a href="/login" class="hover:underline">Admin</a>
+    </div>
+  </nav>
+
+  <section class="text-center py-24">
+    <h1 class="text-5xl font-bold mb-6">FineArt Gallery Platform</h1>
+    <p class="text-lg text-gray-600 mb-8">Welcome to FineArtSuite, the easiest way to manage your online art gallery.</p>
+    <p class="mb-2"><a class="underline" href="/demo-gallery">View demo gallery</a></p>
+    <p><a class="underline" href="/login">Admin Login</a></p>
   </section>
+
+  <footer class="text-center py-6 border-t border-gray-200">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style navigation, hero sections and footer with Tailwind for a clean monochrome look
- apply responsive layouts for galleries, artist profiles and artwork details
- document sample EJS snippets for navigation, hero and artwork grids

## Testing
- `npm run build:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e0a6302ec8320b80b48ef67c6c455