### PR TITLE
feat: add gallery settings and expanded forms

### DIFF
--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -13,7 +13,9 @@ function getArtwork(gallerySlug, id, cb) {
       dimensions: row.dimensions,
       price: row.price,
       image: row.image,
-      status: row.status
+      status: row.status,
+      hide_collected: row.hide_collected,
+      featured: row.featured
     };
     cb(null, { artwork, artistId: row.artistId });
   });

--- a/models/db.js
+++ b/models/db.js
@@ -22,6 +22,18 @@ function initialize() {
     db.run('ALTER TABLE artists ADD COLUMN bioImageUrl TEXT', () => {});
     db.run('ALTER TABLE artists ADD COLUMN fullBio TEXT', () => {});
 
+    db.run(`CREATE TABLE IF NOT EXISTS gallery_settings (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      name TEXT,
+      slug TEXT,
+      phone TEXT,
+      email TEXT,
+      address TEXT,
+      description TEXT,
+      owner TEXT,
+      logo TEXT
+    )`);
+
     db.run(`CREATE TABLE IF NOT EXISTS artworks (
       id TEXT PRIMARY KEY,
       artist_id TEXT,
@@ -30,9 +42,13 @@ function initialize() {
       dimensions TEXT,
       price TEXT,
       image TEXT,
-      status TEXT
+      status TEXT,
+      hide_collected INTEGER DEFAULT 0,
+      featured INTEGER DEFAULT 0
     )`);
     db.run('ALTER TABLE artworks ADD COLUMN status TEXT', () => {});
+    db.run('ALTER TABLE artworks ADD COLUMN hide_collected INTEGER DEFAULT 0', () => {});
+    db.run('ALTER TABLE artworks ADD COLUMN featured INTEGER DEFAULT 0', () => {});
 
     db.get('SELECT COUNT(*) as count FROM galleries', (err, row) => {
       if (err) return;
@@ -71,30 +87,30 @@ function seed(done) {
     'Ava Patel explores human connection through digital mediums.\n\nHer creations blur the line between code and compassion.');
   artistStmt.finalize();
 
-  const artworkStmt = db.prepare('INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, image, status) VALUES (?,?,?,?,?,?,?,?)');
-  artworkStmt.run('art1', 'artist1', 'Dreamscape', 'Oil on Canvas', '30x40', '$4000', 'https://picsum.photos/id/205/420/630', 'available');
-  artworkStmt.run('art2', 'artist1', 'Ocean Depths', 'Acrylic', '24x36', '$2500', 'https://picsum.photos/id/207/380/560', 'available');
-  artworkStmt.run('c1', 'artist2', 'City Lights', 'Oil on Canvas', '24x30', '$3500', 'https://picsum.photos/id/208/360/540', 'available');
-  artworkStmt.run('art3', 'artist3', 'Forest Whisper', 'Watercolor', '18x24', '$1800', 'https://picsum.photos/id/209/340/520', 'available');
-  artworkStmt.run('art4', 'artist4', 'Dream Horizon', 'Digital', '1920x1080', '$1200', 'https://picsum.photos/id/206/400/600', 'available');
+  const artworkStmt = db.prepare('INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, image, status, hide_collected, featured) VALUES (?,?,?,?,?,?,?,?,?,?)');
+  artworkStmt.run('art1', 'artist1', 'Dreamscape', 'Oil on Canvas', '30x40', '$4000', 'https://picsum.photos/id/205/420/630', 'available', 0, 0);
+  artworkStmt.run('art2', 'artist1', 'Ocean Depths', 'Acrylic', '24x36', '$2500', 'https://picsum.photos/id/207/380/560', 'available', 0, 0);
+  artworkStmt.run('c1', 'artist2', 'City Lights', 'Oil on Canvas', '24x30', '$3500', 'https://picsum.photos/id/208/360/540', 'available', 0, 0);
+  artworkStmt.run('art3', 'artist3', 'Forest Whisper', 'Watercolor', '18x24', '$1800', 'https://picsum.photos/id/209/340/520', 'available', 0, 0);
+  artworkStmt.run('art4', 'artist4', 'Dream Horizon', 'Digital', '1920x1080', '$1200', 'https://picsum.photos/id/206/400/600', 'available', 0, 0);
 
-  artworkStmt.run('sophia1', 'artist5', 'Stone Echo', 'Marble', '20x40', '$5000', 'https://picsum.photos/id/210/400/600', 'available');
-  artworkStmt.run('sophia2', 'artist5', 'Urban Rhythm', 'Bronze', '15x30', '$3200', 'https://picsum.photos/id/215/350/500', 'available');
-  artworkStmt.run('sophia3', 'artist5', 'Silent Form', 'Marble', '25x50', '$4800', 'https://picsum.photos/id/220/360/540', 'available');
-  artworkStmt.run('sophia4', 'artist5', 'Echoed Motion', 'Granite', '18x36', '$4100', 'https://picsum.photos/id/225/370/560', 'available');
-  artworkStmt.run('sophia5', 'artist5', 'Timeless Curve', 'Limestone', '22x44', '$4500', 'https://picsum.photos/id/230/380/580', 'available');
+  artworkStmt.run('sophia1', 'artist5', 'Stone Echo', 'Marble', '20x40', '$5000', 'https://picsum.photos/id/210/400/600', 'available', 0, 0);
+  artworkStmt.run('sophia2', 'artist5', 'Urban Rhythm', 'Bronze', '15x30', '$3200', 'https://picsum.photos/id/215/350/500', 'available', 0, 0);
+  artworkStmt.run('sophia3', 'artist5', 'Silent Form', 'Marble', '25x50', '$4800', 'https://picsum.photos/id/220/360/540', 'available', 0, 0);
+  artworkStmt.run('sophia4', 'artist5', 'Echoed Motion', 'Granite', '18x36', '$4100', 'https://picsum.photos/id/225/370/560', 'available', 0, 0);
+  artworkStmt.run('sophia5', 'artist5', 'Timeless Curve', 'Limestone', '22x44', '$4500', 'https://picsum.photos/id/230/380/580', 'available', 0, 0);
 
-  artworkStmt.run('luca1', 'artist6', 'City Pulse', 'Oil on Canvas', '28x40', '$3600', 'https://picsum.photos/id/235/320/480', 'available');
-  artworkStmt.run('luca2', 'artist6', 'Neon Nights', 'Oil on Canvas', '30x45', '$3900', 'https://picsum.photos/id/240/330/500', 'available');
-  artworkStmt.run('luca3', 'artist6', 'Market Rush', 'Acrylic', '24x36', '$3100', 'https://picsum.photos/id/245/340/520', 'available');
-  artworkStmt.run('luca4', 'artist6', 'Dawn Commute', 'Oil on Canvas', '26x38', '$3300', 'https://picsum.photos/id/250/350/530', 'available');
-  artworkStmt.run('luca5', 'artist6', 'Steel & Sky', 'Mixed Media', '32x48', '$4200', 'https://picsum.photos/id/260/360/540', 'available');
+  artworkStmt.run('luca1', 'artist6', 'City Pulse', 'Oil on Canvas', '28x40', '$3600', 'https://picsum.photos/id/235/320/480', 'available', 0, 0);
+  artworkStmt.run('luca2', 'artist6', 'Neon Nights', 'Oil on Canvas', '30x45', '$3900', 'https://picsum.photos/id/240/330/500', 'available', 0, 0);
+  artworkStmt.run('luca3', 'artist6', 'Market Rush', 'Acrylic', '24x36', '$3100', 'https://picsum.photos/id/245/340/520', 'available', 0, 0);
+  artworkStmt.run('luca4', 'artist6', 'Dawn Commute', 'Oil on Canvas', '26x38', '$3300', 'https://picsum.photos/id/250/350/530', 'available', 0, 0);
+  artworkStmt.run('luca5', 'artist6', 'Steel & Sky', 'Mixed Media', '32x48', '$4200', 'https://picsum.photos/id/260/360/540', 'available', 0, 0);
 
-  artworkStmt.run('ava1', 'artist7', 'Digital Bloom', 'Digital', '1920x1080', '$1500', 'https://picsum.photos/id/265/310/460', 'available');
-  artworkStmt.run('ava2', 'artist7', 'Neural Path', 'Digital', '1920x1200', '$1600', 'https://picsum.photos/id/270/320/480', 'available');
-  artworkStmt.run('ava3', 'artist7', 'Emote Wave', 'Digital', '2000x1300', '$1700', 'https://picsum.photos/id/275/330/500', 'available');
-  artworkStmt.run('ava4', 'artist7', 'Circuit Dream', 'Digital', '1800x1100', '$1550', 'https://picsum.photos/id/280/340/520', 'available');
-  artworkStmt.run('ava5', 'artist7', 'Binary Sunset', 'Digital', '2200x1400', '$1800', 'https://picsum.photos/id/285/350/540', 'available');
+  artworkStmt.run('ava1', 'artist7', 'Digital Bloom', 'Digital', '1920x1080', '$1500', 'https://picsum.photos/id/265/310/460', 'available', 0, 0);
+  artworkStmt.run('ava2', 'artist7', 'Neural Path', 'Digital', '1920x1200', '$1600', 'https://picsum.photos/id/270/320/480', 'available', 0, 0);
+  artworkStmt.run('ava3', 'artist7', 'Emote Wave', 'Digital', '2000x1300', '$1700', 'https://picsum.photos/id/275/330/500', 'available', 0, 0);
+  artworkStmt.run('ava4', 'artist7', 'Circuit Dream', 'Digital', '1800x1100', '$1550', 'https://picsum.photos/id/280/340/520', 'available', 0, 0);
+  artworkStmt.run('ava5', 'artist7', 'Binary Sunset', 'Digital', '2200x1400', '$1800', 'https://picsum.photos/id/285/350/540', 'available', 0, 0);
 
   artworkStmt.finalize(() => {
     if (done) done();

--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -25,20 +25,32 @@
       <% } %>
       <form id="add-artist" method="post" action="/dashboard/artists" class="space-y-4">
         <div>
-          <label class="block text-sm font-medium" for="id">ID</label>
-          <input id="id" type="text" name="id" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+          <label class="block text-sm font-medium" for="id">Artist ID</label>
+          <input id="id" type="text" name="id" value="<%= generatedId %>" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1 bg-gray-100">
         </div>
         <div>
           <label class="block text-sm font-medium" for="gallery_slug">Gallery Slug</label>
-          <input id="gallery_slug" type="text" name="gallery_slug" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+          <select id="gallery_slug" name="gallery_slug" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+            <% galleries.forEach(function(g){ %>
+              <option value="<%= g.slug %>"><%= g.slug %></option>
+            <% }) %>
+          </select>
         </div>
         <div>
           <label class="block text-sm font-medium" for="name">Name</label>
           <input id="name" type="text" name="name" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
         </div>
         <div>
-          <label class="block text-sm font-medium" for="bio">Bio</label>
-          <input id="bio" type="text" name="bio" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+          <label class="block text-sm font-medium" for="bio">Brief Bio</label>
+          <textarea id="bio" name="bio" rows="3" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1"></textarea>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="fullBio">Extended Bio</label>
+          <textarea id="fullBio" name="fullBio" rows="5" class="mt-1 w-full border border-gray-300 rounded px-2 py-1"></textarea>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="bioImageUrl">Artist Portrait URL</label>
+          <input id="bioImageUrl" type="text" name="bioImageUrl" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
         </div>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Add Artist</button>
@@ -47,13 +59,22 @@
       <ul class="space-y-4">
         <% artists.forEach(function(a){ %>
           <li>
-            <form class="artist-form flex flex-col sm:flex-row sm:items-center gap-2" data-id="<%= a.id %>">
-              <input name="name" value="<%= a.name %>" class="border border-gray-300 rounded px-2 py-1 flex-1">
-              <input name="bio" value="<%= a.bio %>" class="border border-gray-300 rounded px-2 py-1 flex-1">
-              <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded">Save</button>
-              <button type="button" class="delete bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded">Delete</button>
+            <form class="artist-form space-y-2" data-id="<%= a.id %>">
+              <input name="name" value="<%= a.name %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <textarea name="bio" rows="3" class="border border-gray-300 rounded px-2 py-1 w-full"><%= a.bio %></textarea>
+              <textarea name="fullBio" rows="5" class="border border-gray-300 rounded px-2 py-1 w-full"><%= a.fullBio %></textarea>
+              <input name="bioImageUrl" value="<%= a.bioImageUrl %>" class="border border-gray-300 rounded px-2 py-1 w-full" placeholder="Portrait URL">
+              <select name="gallery_slug" class="border border-gray-300 rounded px-2 py-1 w-full">
+                <% galleries.forEach(function(g){ %>
+                  <option value="<%= g.slug %>" <%= g.slug === a.gallery_slug ? 'selected' : '' %>><%= g.slug %></option>
+                <% }) %>
+              </select>
+              <div class="flex gap-2">
+                <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded">Save</button>
+                <button type="button" class="delete bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded">Delete</button>
+              </div>
             </form>
-            <span class="text-sm text-gray-600">(<%= a.gallery_slug %>)</span>
+            <span class="text-sm text-gray-600">ID: <%= a.id %></span>
           </li>
         <% }) %>
       </ul>

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -25,8 +25,8 @@
       <% } %>
       <form id="add-art" method="post" action="/dashboard/artworks" class="space-y-4">
         <div>
-          <label class="block text-sm font-medium" for="id">ID</label>
-          <input id="id" type="text" name="id" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+          <label class="block text-sm font-medium" for="id">Artwork ID</label>
+          <input id="id" type="text" name="id" value="<%= generatedId %>" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1 bg-gray-100">
         </div>
         <div>
           <label class="block text-sm font-medium" for="artist_id">Artist ID</label>
@@ -52,6 +52,24 @@
           <label class="block text-sm font-medium" for="image">Image</label>
           <input id="image" type="text" name="image" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
         </div>
+        <div>
+          <label class="block text-sm font-medium" for="status">Availability</label>
+          <select id="status" name="status" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+            <option value=""></option>
+            <option value="inquire">Inquire</option>
+            <option value="offer">Make an Offer</option>
+            <option value="available" selected>Available</option>
+            <option value="collected">Red Dot Collected</option>
+          </select>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="hide_collected" name="hide_collected" value="1" class="mr-2">
+          <label for="hide_collected" class="text-sm">Hide if collected</label>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="featured" name="featured" value="1" class="mr-2">
+          <label for="featured" class="text-sm">Featured</label>
+        </div>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Add Artwork</button>
       </form>
@@ -59,13 +77,28 @@
       <ul class="space-y-4">
         <% artworks.forEach(function(art){ %>
           <li>
-            <form class="art-form flex flex-col sm:grid sm:grid-cols-5 sm:gap-2 gap-2" data-id="<%= art.id %>">
-              <input name="title" value="<%= art.title %>" class="border border-gray-300 rounded px-2 py-1">
-              <input name="medium" value="<%= art.medium %>" class="border border-gray-300 rounded px-2 py-1">
-              <input name="dimensions" value="<%= art.dimensions %>" class="border border-gray-300 rounded px-2 py-1">
-              <input name="price" value="<%= art.price %>" class="border border-gray-300 rounded px-2 py-1">
-              <input name="image" value="<%= art.image %>" class="border border-gray-300 rounded px-2 py-1">
-              <div class="flex gap-2 mt-2 sm:col-span-5">
+            <form class="art-form space-y-2" data-id="<%= art.id %>">
+              <input name="title" value="<%= art.title %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <input name="medium" value="<%= art.medium %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <input name="dimensions" value="<%= art.dimensions %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <input name="price" value="<%= art.price %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <input name="image" value="<%= art.image %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <select name="status" class="border border-gray-300 rounded px-2 py-1 w-full">
+                <option value="" <%= art.status === '' ? 'selected' : '' %>></option>
+                <option value="inquire" <%= art.status === 'inquire' ? 'selected' : '' %>>Inquire</option>
+                <option value="offer" <%= art.status === 'offer' ? 'selected' : '' %>>Make an Offer</option>
+                <option value="available" <%= art.status === 'available' ? 'selected' : '' %>>Available</option>
+                <option value="collected" <%= art.status === 'collected' ? 'selected' : '' %>>Red Dot Collected</option>
+              </select>
+              <div class="flex items-center">
+                <input type="checkbox" name="hide_collected" value="1" class="mr-2" <%= art.hide_collected ? 'checked' : '' %>>
+                <label class="text-sm">Hide if collected</label>
+              </div>
+              <div class="flex items-center">
+                <input type="checkbox" name="featured" value="1" class="mr-2" <%= art.featured ? 'checked' : '' %>>
+                <label class="text-sm">Featured</label>
+              </div>
+              <div class="flex gap-2">
                 <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded">Save</button>
                 <button type="button" class="delete bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded">Delete</button>
               </div>

--- a/views/admin/settings.ejs
+++ b/views/admin/settings.ejs
@@ -13,11 +13,56 @@
       <a href="/logout" class="hover:underline">Logout</a>
     </div>
   </nav>
-  <main class="max-w-md mx-auto p-6">
-    <div class="border border-gray-200 p-6 rounded shadow text-center">
-      <h1 class="text-2xl mb-4">Settings</h1>
-      <p class="mb-4">Gallery settings interface coming soon.</p>
-      <p><a href="/dashboard" class="text-blue-600 underline">Back to dashboard</a></p>
+  <main class="max-w-xl mx-auto p-6">
+    <div class="border border-gray-200 p-6 rounded shadow">
+      <h1 class="text-2xl mb-4 text-center">Gallery Settings</h1>
+      <% if (flash.error && flash.error.length) { %>
+        <p class="text-red-600 mb-4"><%= flash.error[0] %></p>
+      <% } %>
+      <% if (flash.success && flash.success.length) { %>
+        <p class="text-green-600 mb-4"><%= flash.success[0] %></p>
+      <% } %>
+      <form method="post" action="/dashboard/settings" enctype="multipart/form-data" class="space-y-4">
+        <div>
+          <label class="block text-sm font-medium" for="name">Gallery Name</label>
+          <input type="text" id="name" name="name" value="<%= settings.name || '' %>" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="slug">Gallery Slug</label>
+          <input type="text" id="slug" name="slug" value="<%= settings.slug || '' %>" class="mt-1 w-full border border-gray-300 rounded px-2 py-1 bg-gray-100">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="phone">Phone</label>
+          <input type="text" id="phone" name="phone" value="<%= settings.phone || '' %>" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="email">Email</label>
+          <input type="email" id="email" name="email" value="<%= settings.email || '' %>" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="address">Address</label>
+          <textarea id="address" name="address" rows="2" class="mt-1 w-full border border-gray-300 rounded px-2 py-1"><%= settings.address || '' %></textarea>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="description">Brief Description</label>
+          <textarea id="description" name="description" rows="3" class="mt-1 w-full border border-gray-300 rounded px-2 py-1"><%= settings.description || '' %></textarea>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="owner">Gallery Owner</label>
+          <input type="text" id="owner" name="owner" value="<%= settings.owner || '' %>" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="logo">Logo (optional)</label>
+          <input type="file" id="logo" name="logo" accept="image/*" class="mt-1 w-full">
+          <% if (settings.logo) { %>
+            <img src="/uploads/<%= settings.logo %>" alt="Logo" class="mt-2 max-h-24">
+            <input type="hidden" name="existingLogo" value="<%= settings.logo %>">
+          <% } %>
+        </div>
+        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Save</button>
+      </form>
+      <p class="mt-6 text-center"><a href="/dashboard" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
   <footer class="text-center py-6 border-t border-gray-200 mt-12">

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -22,12 +22,26 @@
       <% } %>
       <form id="upload-form" method="post" action="/dashboard/upload" enctype="multipart/form-data" class="space-y-4">
         <div>
+          <label class="block text-sm font-medium" for="id">Artwork ID</label>
+          <input type="text" id="id" name="id" value="<%= generatedId %>" class="mt-1 w-full border border-gray-300 rounded px-2 py-1 bg-gray-100">
+        </div>
+        <div>
           <label class="block text-sm font-medium" for="title">Title</label>
           <input type="text" id="title" name="title" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
         </div>
         <div>
           <label class="block text-sm font-medium" for="medium">Medium</label>
-          <input type="text" id="medium" name="medium" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+          <select id="medium" name="medium" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+            <option value="Oil">Oil</option>
+            <option value="Acrylic">Acrylic</option>
+            <option value="Mixed Media">Mixed Media</option>
+            <option value="Ink">Ink</option>
+            <option value="Digital">Digital</option>
+            <option value="Sculpture">Sculpture</option>
+            <option value="Print">Print</option>
+            <option value="other">Other</option>
+          </select>
+          <input type="text" id="custom-medium" name="custom_medium" placeholder="Enter medium" class="mt-2 w-full border border-gray-300 rounded px-2 py-1 hidden">
         </div>
         <div>
           <label class="block text-sm font-medium" for="dimensions">Dimensions</label>
@@ -43,11 +57,22 @@
           <img id="preview" src="" alt="Preview" class="mt-2 max-w-full hidden">
         </div>
         <div>
-          <label class="block text-sm font-medium" for="status">Status</label>
+          <label class="block text-sm font-medium" for="status">Availability</label>
           <select id="status" name="status" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
-            <option value="available">Available</option>
-            <option value="sold">Sold</option>
+            <option value=""></option>
+            <option value="inquire">Inquire</option>
+            <option value="offer">Make an Offer</option>
+            <option value="available" selected>Available</option>
+            <option value="collected">Red Dot Collected</option>
           </select>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="hide_collected" name="hide_collected" value="1" class="mr-2">
+          <label for="hide_collected" class="text-sm">Hide if collected</label>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="featured" name="featured" value="1" class="mr-2">
+          <label for="featured" class="text-sm">Featured</label>
         </div>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Submit</button>
@@ -69,12 +94,14 @@
 
   <script>
     const imageInput = document.getElementById('image');
-    const previewImg = document.getElementById('preview');
+  const previewImg = document.getElementById('preview');
+  const mediumSelect = document.getElementById('medium');
+  const customMedium = document.getElementById('custom-medium');
 
-    imageInput.addEventListener('change', function() {
-      const file = this.files[0];
-      if (file) {
-        const reader = new FileReader();
+  imageInput.addEventListener('change', function() {
+    const file = this.files[0];
+    if (file) {
+      const reader = new FileReader();
         reader.onload = function(e) {
           previewImg.src = e.target.result;
           previewImg.classList.remove('hidden');
@@ -82,9 +109,17 @@
         reader.readAsDataURL(file);
       } else {
         previewImg.src = '';
-        previewImg.classList.add('hidden');
-      }
-    });
+      previewImg.classList.add('hidden');
+    }
+  });
+
+  mediumSelect.addEventListener('change', function() {
+    if (this.value === 'other') {
+      customMedium.classList.remove('hidden');
+    } else {
+      customMedium.classList.add('hidden');
+    }
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add gallery settings management with logo upload
- expand artwork and artist forms with IDs, dropdowns and new metadata
- store availability, hide_collected and featured flags in database

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e4aeaa1648320b3279e4454192ba7