### PR TITLE
Display artwork status and hide price when collected

### DIFF
--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -26,7 +26,24 @@
             <a href="/<%= slug %>/artworks/<%= art.id %>" class="block">
               <img src="<%= art.imageThumb %>" alt="<%= art.title %>" class="w-full mb-2 fade-in" loading="lazy" onload="this.classList.add('loaded')">
               <span class="font-semibold block"><%= art.title %></span>
-              <span class="text-sm text-gray-600 block"><%= art.medium %> • <%= art.dimensions %> • <%= art.price %></span>
+
+              <% if (art.status) { %>
+                <% if (art.status === 'collected') { %>
+                  <span class="text-red-500 flex items-center text-sm"><span class="mr-1">&#9679;</span>Collected</span>
+                <% } else if (art.status === 'available') { %>
+                  <span class="text-sm">Available</span>
+                <% } else if (art.status === 'inquire') { %>
+                  <button class="mt-1 text-sm px-2 py-1 border rounded">Inquire</button>
+                <% } else if (art.status === 'make_offer') { %>
+                  <button class="mt-1 text-sm px-2 py-1 border rounded">Make an Offer</button>
+                <% } %>
+              <% } %>
+
+              <% const showPrice = !(art.status === 'collected' && art.price); %>
+              <span class="text-sm text-gray-600 block">
+                <%= art.medium %> • <%= art.dimensions %>
+                <% if (showPrice && art.price) { %> • <%= art.price %><% } %>
+              </span>
             </a>
           </li>
         <% }) %>

--- a/views/artwork-detail.ejs
+++ b/views/artwork-detail.ejs
@@ -16,6 +16,18 @@
   <main class="max-w-3xl mx-auto p-6">
     <header class="text-center mb-8">
       <h1 class="text-4xl font-bold mb-4"><%= artwork.title %></h1>
+
+      <% if (artwork.status) { %>
+        <% if (artwork.status === 'collected') { %>
+          <p class="text-red-500 flex items-center justify-center"><span class="mr-1">&#9679;</span>Collected</p>
+        <% } else if (artwork.status === 'available') { %>
+          <p>Available</p>
+        <% } else if (artwork.status === 'inquire') { %>
+          <button class="mt-2 px-2 py-1 border rounded">Inquire</button>
+        <% } else if (artwork.status === 'make_offer') { %>
+          <button class="mt-2 px-2 py-1 border rounded">Make an Offer</button>
+        <% } %>
+      <% } %>
     </header>
 
     <div class="mb-8">
@@ -25,7 +37,9 @@
     <ul class="max-w-md mx-auto divide-y divide-gray-200 text-center">
       <li class="py-2">Medium: <span class="font-semibold"><%= artwork.medium %></span></li>
       <li class="py-2">Dimensions: <span class="font-semibold"><%= artwork.dimensions %></span></li>
-      <li class="py-2">Price: <span class="font-semibold"><%= artwork.price %></span></li>
+      <% if (!(artwork.status === 'collected' && artwork.price)) { %>
+        <li class="py-2">Price: <span class="font-semibold"><%= artwork.price %></span></li>
+      <% } %>
     </ul>
 
     <div class="mt-8 text-center">

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -23,6 +23,24 @@
       <div class="text-center">
         <img src="<%= gallery.featuredArtwork.imageStandard %>" alt="<%= gallery.featuredArtwork.title %>" class="mx-auto max-w-sm fade-in" loading="lazy" onload="this.classList.add('loaded')">
         <p class="mt-4 font-semibold"><%= gallery.featuredArtwork.title %></p>
+
+        <% if (gallery.featuredArtwork.status) { %>
+          <% if (gallery.featuredArtwork.status === 'collected') { %>
+            <p class="text-red-500 flex items-center justify-center text-sm"><span class="mr-1">&#9679;</span>Collected</p>
+          <% } else if (gallery.featuredArtwork.status === 'available') { %>
+            <p class="text-sm">Available</p>
+          <% } else if (gallery.featuredArtwork.status === 'inquire') { %>
+            <button class="mt-2 px-2 py-1 text-sm border rounded">Inquire</button>
+          <% } else if (gallery.featuredArtwork.status === 'make_offer') { %>
+            <button class="mt-2 px-2 py-1 text-sm border rounded">Make an Offer</button>
+          <% } %>
+        <% } %>
+
+        <% const showPrice = !(gallery.featuredArtwork.status === 'collected' && gallery.featuredArtwork.price); %>
+        <p class="text-sm text-gray-600">
+          <%= gallery.featuredArtwork.medium %> • <%= gallery.featuredArtwork.dimensions %>
+          <% if (showPrice && gallery.featuredArtwork.price) { %> • <%= gallery.featuredArtwork.price %><% } %>
+        </p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- show artwork status (Collected, Available, Inquire, Make an Offer) across gallery, artist, and artwork pages
- hide price when status is collected

## Testing
- `npm test` *(fails: authenticated upload stores file, DB entry, and is served)*

------
https://chatgpt.com/codex/tasks/task_e_688e4f77f6708320a09784543d2f2aa2