### PR TITLE
Refine gallery artwork display

### DIFF
--- a/server.js
+++ b/server.js
@@ -82,9 +82,9 @@ async function processImages(file) {
   if (Jimp) {
     try {
       const image = await Jimp.read(file.path);
-      await image.clone().scaleToFit(1000, 1000).writeAsync(fullPath);
-      await image.clone().scaleToFit(1000, 1000).writeAsync(standardPath);
-      await image.clone().scaleToFit(500, 500).writeAsync(thumbPath);
+      await image.clone().scaleToFit(2000, 2000).writeAsync(fullPath);
+      await image.clone().scaleToFit(800, 800).writeAsync(standardPath);
+      await image.clone().cover(300, 300).writeAsync(thumbPath);
     } catch {
       fs.copyFileSync(file.path, fullPath);
       fs.copyFileSync(file.path, standardPath);

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -25,18 +25,37 @@
 
     <section class="mb-12">
       <h2 class="text-xl font-bold mb-4">Featured Artworks</h2>
-      <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      <ul class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
         <% gallery.featuredArtworks.forEach(function(art){ %>
-          <li class="<%= art.isFeatured ? 'md:col-span-2' : '' %>">
-            <a href="/<%= slug %>/artworks/<%= art.id %>" class="block text-center">
-              <img src="<%= art.imageThumb %>" alt="<%= art.title %>" class="mx-auto mb-2 transition-opacity duration-700 opacity-0" loading="lazy" onload="this.classList.remove('opacity-0')">
-              <span class="font-semibold block"><%= art.title %></span>
-              <% if (art.status === 'collected') { %>
-                <span class="text-red-500 flex items-center justify-center text-sm">
-                  <span class="inline-block w-2 h-2 bg-red-500 rounded-full mr-1"></span>
-                  Collected
-                </span>
-              <% } %>
+          <li>
+            <a href="/<%= slug %>/artworks/<%= art.id %>" class="group block text-center">
+              <div class="relative w-full h-[300px] overflow-hidden">
+                <img src="<%= art.imageThumb %>" alt="<%= art.title %>" loading="lazy"
+                     class="w-full h-full object-cover aspect-square transition-opacity duration-700 opacity-0" onload="this.classList.remove('opacity-0')">
+                <img src="<%= art.imageStandard %>" alt="<%= art.title %>" loading="lazy"
+                     class="absolute inset-0 w-full h-full object-contain opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus:opacity-100 pointer-events-none">
+              </div>
+              <div class="mt-2 space-y-1">
+                <span class="font-semibold block"><%= art.title %></span>
+                <% if (art.status) { %>
+                  <% if (art.status === 'collected') { %>
+                    <span class="text-red-500 flex items-center justify-center text-sm">
+                      <span class="inline-block w-2 h-2 bg-red-500 rounded-full mr-1"></span>
+                      Collected
+                    </span>
+                  <% } else if (art.status === 'available') { %>
+                    <span class="text-sm">Available</span>
+                  <% } else if (art.status === 'inquire') { %>
+                    <button class="mt-1 text-sm px-2 py-1 border rounded">Inquire</button>
+                  <% } else if (art.status === 'make_offer') { %>
+                    <button class="mt-1 text-sm px-2 py-1 border rounded">Make an Offer</button>
+                  <% } %>
+                <% } %>
+                <% const showPrice = !(art.status === 'collected' && art.price); %>
+                <% if (art.price && showPrice) { %>
+                  <span class="text-sm text-gray-600 block"><%= art.price %></span>
+                <% } %>
+              </div>
             </a>
           </li>
         <% }) %>


### PR DESCRIPTION
## Summary
- Implement Tailwind responsive grid and square thumbnail containers for gallery artworks with hover reveal
- Add price/status styling and lazy loading; update backend image processing sizes (300/800/2000)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e5b2303c4832082acb3bb9d818646