### PR TITLE
Use gallery artists dropdown

### DIFF
--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -236,6 +236,7 @@ test('admin artwork routes allow CRUD after login', async () => {
   let res = await httpPostForm(`http://localhost:${port}/dashboard/artworks`, {
     id,
     artist_id: 'artist1',
+    gallery_slug: 'demo-gallery',
     title: 'NewArt',
     medium: 'Oil',
     dimensions: '1x1',
@@ -330,7 +331,7 @@ test('artist and artwork routes require login', async () => {
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
 
-  res = await httpPostForm(`http://localhost:${port}/dashboard/artworks`, { id: 'x', artist_id: 'artist1', title: 't', medium: 'm', dimensions: 'd', price: 'p', imageUrl: 'i', _csrf: token }, cookie);
+  res = await httpPostForm(`http://localhost:${port}/dashboard/artworks`, { id: 'x', artist_id: 'artist1', gallery_slug: 'demo-gallery', title: 't', medium: 'm', dimensions: 'd', price: 'p', imageUrl: 'i', _csrf: token }, cookie);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
   res = await httpRequest('PUT', `http://localhost:${port}/dashboard/artworks/x`, { title: 't' }, cookie, token);

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -37,8 +37,8 @@
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium" for="artist_id">Artist ID</label>
-          <input id="artist_id" type="text" name="artist_id" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+          <label class="block text-sm font-medium" for="artist_id">Artist</label>
+          <select id="artist_id" name="artist_id" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1"></select>
         </div>
         <div>
           <label class="block text-sm font-medium" for="title">Title</label>
@@ -191,6 +191,28 @@
 
     document.querySelectorAll('.medium-select').forEach(handleMediumSelect);
     document.querySelectorAll('.status-select').forEach(handleStatusSelect);
+
+    async function loadArtists(slug) {
+      try {
+        const res = await fetch('/dashboard/artists?gallery_slug=' + encodeURIComponent(slug), { headers: { 'Accept': 'application/json' } });
+        if (!res.ok) return;
+        const artists = await res.json();
+        const select = document.getElementById('artist_id');
+        select.innerHTML = '';
+        artists.forEach(a => {
+          const opt = document.createElement('option');
+          opt.value = a.id;
+          opt.textContent = a.name;
+          select.appendChild(opt);
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    const gallerySelect = document.getElementById('gallery_slug');
+    gallerySelect.addEventListener('change', e => loadArtists(e.target.value));
+    loadArtists(gallerySelect.value);
 
     const addForm = document.getElementById('add-art');
     addForm.addEventListener('submit', async e => {


### PR DESCRIPTION
## Summary
- Replace free-form artist field with a gallery-aware dropdown populated from `/dashboard/artists`.
- Dynamically refresh artists on gallery selection and ensure server validates artist-gallery relationship.
- Adjust tests for new gallery association requirement.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e62c388dc83209ad285fc1d06d772