### PR TITLE
Add admin galleries management

### DIFF
--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -15,7 +15,11 @@
     </nav>
   <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-8 text-center">Admin Dashboard</h1>
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 sm:grid-cols-4 gap-6">
+      <a href="/dashboard/galleries" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">
+        <svg class="w-8 h-8 md:w-6 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h18M3 17h18"/></svg>
+        <span class="mt-2 font-semibold">Galleries</span>
+      </a>
       <a href="/dashboard/artists" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">
         <svg class="w-8 h-8 md:w-6 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path></svg>
         <span class="mt-2 font-semibold">Artists</span>

--- a/views/admin/galleries.ejs
+++ b/views/admin/galleries.ejs
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Manage Galleries</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+  <meta name="csrf-token" content="<%= csrfToken %>">
+</head>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex space-x-4 mt-2 md:mt-0">
+      <a href="/dashboard" class="hover:underline">Dashboard</a>
+      <a href="/logout" class="hover:underline">Logout</a>
+    </div>
+  </nav>
+  <main class="max-w-3xl mx-auto p-6">
+    <div class="border border-gray-200 p-6 rounded shadow">
+      <h1 class="text-2xl mb-4 text-center">Gallery Management</h1>
+      <% if (flash.error && flash.error.length) { %>
+        <p class="text-red-600 mb-4"><%= flash.error[0] %></p>
+      <% } %>
+      <% if (flash.success && flash.success.length) { %>
+        <p class="text-green-600 mb-4"><%= flash.success[0] %></p>
+      <% } %>
+      <form id="add-gallery" method="post" action="/dashboard/galleries" class="space-y-4">
+        <div>
+          <label class="block text-sm font-medium" for="slug">Slug</label>
+          <input id="slug" type="text" name="slug" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="name">Name</label>
+          <input id="name" type="text" name="name" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="bio">Bio</label>
+          <textarea id="bio" name="bio" rows="3" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1"></textarea>
+        </div>
+        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+        <button type="submit" class="save-btn bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center justify-center">
+          <span class="status-text">Add Gallery</span>
+        </button>
+      </form>
+      <h2 class="text-xl mt-8 mb-4">Existing Galleries</h2>
+      <ul class="space-y-4">
+        <% galleries.forEach(function(g){ %>
+          <li>
+            <form class="gallery-form space-y-2" data-slug="<%= g.slug %>">
+              <input name="slug" value="<%= g.slug %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <input name="name" value="<%= g.name %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+              <textarea name="bio" rows="3" class="border border-gray-300 rounded px-2 py-1 w-full"><%= g.bio %></textarea>
+              <div class="flex gap-2">
+                <button type="submit" class="save-btn bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded flex items-center justify-center">
+                  <span class="status-text">Save</span>
+                </button>
+                <button type="button" class="delete bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded">Delete</button>
+              </div>
+            </form>
+            <span class="text-sm text-gray-600">Slug: <%= g.slug %></span>
+          </li>
+        <% }) %>
+      </ul>
+      <p class="mt-6"><a href="/dashboard" class="text-blue-600 underline">Back to dashboard</a></p>
+    </div>
+  </main>
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+  <script>
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+    const addForm = document.getElementById('add-gallery');
+    addForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const btn = addForm.querySelector('.save-btn');
+      const label = btn.querySelector('.status-text');
+      const original = label.textContent;
+      btn.disabled = true;
+      label.innerHTML = `<svg class="animate-spin h-4 w-4 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>Saving…`;
+      const data = Object.fromEntries(new FormData(addForm).entries());
+      await fetch('/dashboard/galleries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken },
+        body: JSON.stringify(data)
+      });
+      btn.disabled = false;
+      label.textContent = 'Saved!';
+      setTimeout(() => {
+        label.textContent = original;
+        location.reload();
+      }, 2000);
+    });
+
+    document.querySelectorAll('.gallery-form').forEach(f => {
+      let currentSlug = f.dataset.slug;
+      const btn = f.querySelector('.save-btn');
+      const label = btn.querySelector('.status-text');
+      const original = label.textContent;
+      f.addEventListener('submit', async e => {
+        e.preventDefault();
+        btn.disabled = true;
+        label.innerHTML = `<svg class="animate-spin h-4 w-4 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>Saving…`;
+        const data = Object.fromEntries(new FormData(f).entries());
+        await fetch('/dashboard/galleries/' + encodeURIComponent(currentSlug), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken },
+          body: JSON.stringify(data)
+        });
+        btn.disabled = false;
+        label.textContent = 'Saved!';
+        currentSlug = data.slug;
+        f.dataset.slug = currentSlug;
+        setTimeout(() => {
+          label.textContent = original;
+        }, 2000);
+      });
+      f.querySelector('.delete').addEventListener('click', async e => {
+        e.preventDefault();
+        await fetch('/dashboard/galleries/' + encodeURIComponent(currentSlug), {
+          method: 'DELETE',
+          headers: { 'CSRF-Token': csrfToken }
+        });
+        location.reload();
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/dashboard/galleries` view with forms to create, edit, and remove galleries
- implement RESTful `/dashboard/galleries` routes backed by the `galleries` table
- link galleries management from the dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e62c5aa6c8320a81ba23116621260