### PR TITLE
Handle fetch errors on admin forms

### DIFF
--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -100,17 +100,27 @@
       btn.disabled = true;
       label.innerHTML = `<svg class="animate-spin h-4 w-4 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>Saving…`;
       const data = Object.fromEntries(new FormData(addForm).entries());
-      await fetch('/dashboard/artists', {
-        method: 'POST',
-        headers: { 'Content-Type':'application/json', 'CSRF-Token': csrfToken },
-        body: JSON.stringify(data)
-      });
-      btn.disabled = false;
-      label.textContent = 'Saved!';
-      setTimeout(() => {
-        label.textContent = original;
-        location.reload();
-      }, 2000);
+      try {
+        const res = await fetch('/dashboard/artists', {
+          method: 'POST',
+          headers: { 'Content-Type':'application/json', 'CSRF-Token': csrfToken },
+          body: JSON.stringify(data)
+        });
+        if (!res.ok) {
+          const errText = await res.text();
+          throw new Error(errText || res.statusText);
+        }
+        btn.disabled = false;
+        label.textContent = 'Saved!';
+        setTimeout(() => {
+          label.textContent = original;
+          location.reload();
+        }, 2000);
+      } catch (err) {
+        label.textContent = 'Save failed' + (err.message ? ': ' + err.message : '');
+        btn.disabled = false;
+        setTimeout(() => { label.textContent = original; }, 2000);
+      }
     });
 
     document.querySelectorAll('.artist-form').forEach(f => {
@@ -123,21 +133,41 @@
         btn.disabled = true;
         label.innerHTML = `<svg class="animate-spin h-4 w-4 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>Saving…`;
         const data = Object.fromEntries(new FormData(f).entries());
-        await fetch('/dashboard/artists/' + id, {
-          method: 'PUT',
-          headers: {'Content-Type':'application/json', 'CSRF-Token': csrfToken},
-          body: JSON.stringify(data)
-        });
-        btn.disabled = false;
-        label.textContent = 'Saved!';
-        setTimeout(() => {
-          label.textContent = original;
-        }, 2000);
+        try {
+          const res = await fetch('/dashboard/artists/' + id, {
+            method: 'PUT',
+            headers: {'Content-Type':'application/json', 'CSRF-Token': csrfToken},
+            body: JSON.stringify(data)
+          });
+          if (!res.ok) {
+            const errText = await res.text();
+            throw new Error(errText || res.statusText);
+          }
+          btn.disabled = false;
+          label.textContent = 'Saved!';
+          setTimeout(() => {
+            label.textContent = original;
+          }, 2000);
+        } catch (err) {
+          label.textContent = 'Save failed' + (err.message ? ': ' + err.message : '');
+          btn.disabled = false;
+          setTimeout(() => { label.textContent = original; }, 2000);
+        }
       });
       f.querySelector('.delete').addEventListener('click', async e => {
         e.preventDefault();
-        await fetch('/dashboard/artists/' + id, { method: 'DELETE', headers: { 'CSRF-Token': csrfToken } });
-        location.reload();
+        try {
+          const res = await fetch('/dashboard/artists/' + id, { method: 'DELETE', headers: { 'CSRF-Token': csrfToken } });
+          if (!res.ok) {
+            const errText = await res.text();
+            throw new Error(errText || res.statusText);
+          }
+          location.reload();
+        } catch (err) {
+          label.textContent = 'Delete failed' + (err.message ? ': ' + err.message : '');
+          btn.disabled = false;
+          setTimeout(() => { label.textContent = original; }, 2000);
+        }
       });
     });
   </script>

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -201,13 +201,23 @@
       btn.disabled = true;
       label.textContent = 'Saving...';
       const data = new FormData(addForm);
-      await fetch('/dashboard/artworks', {
-        method: 'POST',
-        headers: { 'CSRF-Token': csrfToken },
-        body: data
-      });
-      label.textContent = 'Saved!';
-      setTimeout(() => { location.reload(); }, 1500);
+      try {
+        const res = await fetch('/dashboard/artworks', {
+          method: 'POST',
+          headers: { 'CSRF-Token': csrfToken },
+          body: data
+        });
+        if (!res.ok) {
+          const errText = await res.text();
+          throw new Error(errText || res.statusText);
+        }
+        label.textContent = 'Saved!';
+        setTimeout(() => { location.reload(); }, 1500);
+      } catch (err) {
+        label.textContent = 'Save failed' + (err.message ? ': ' + err.message : '');
+        btn.disabled = false;
+        setTimeout(() => { label.textContent = original; }, 2000);
+      }
     });
 
     document.querySelectorAll('.art-form').forEach(f => {
@@ -220,18 +230,38 @@
         btn.disabled = true;
         label.textContent = 'Saving...';
         const formData = new FormData(f);
-        await fetch('/dashboard/artworks/' + id, {
-          method: 'PUT',
-          headers: { 'CSRF-Token': csrfToken },
-          body: formData
-        });
-        label.textContent = 'Saved!';
-        setTimeout(() => { label.textContent = original; btn.disabled = false; }, 1500);
+        try {
+          const res = await fetch('/dashboard/artworks/' + id, {
+            method: 'PUT',
+            headers: { 'CSRF-Token': csrfToken },
+            body: formData
+          });
+          if (!res.ok) {
+            const errText = await res.text();
+            throw new Error(errText || res.statusText);
+          }
+          label.textContent = 'Saved!';
+          setTimeout(() => { label.textContent = original; btn.disabled = false; }, 1500);
+        } catch (err) {
+          label.textContent = 'Save failed' + (err.message ? ': ' + err.message : '');
+          btn.disabled = false;
+          setTimeout(() => { label.textContent = original; }, 2000);
+        }
       });
       f.querySelector('.delete').addEventListener('click', async e => {
         e.preventDefault();
-        await fetch('/dashboard/artworks/' + id, { method: 'DELETE', headers: { 'CSRF-Token': csrfToken } });
-        location.reload();
+        try {
+          const res = await fetch('/dashboard/artworks/' + id, { method: 'DELETE', headers: { 'CSRF-Token': csrfToken } });
+          if (!res.ok) {
+            const errText = await res.text();
+            throw new Error(errText || res.statusText);
+          }
+          location.reload();
+        } catch (err) {
+          label.textContent = 'Delete failed' + (err.message ? ': ' + err.message : '');
+          btn.disabled = false;
+          setTimeout(() => { label.textContent = original; }, 2000);
+        }
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- add error handling for artwork CRUD actions to surface server failures and re-enable buttons
- add error handling for artist CRUD actions to display failure messages and re-enable controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e62c76bec8320bef8b21855891355