### PR TITLE
feat: add artist and gallery account types

### DIFF
--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -25,4 +25,12 @@ function getArtwork(gallerySlug, id, cb) {
   });
 }
 
-module.exports = { getArtwork };
+function getArtworksByArtist(artistId, cb) {
+  db.all('SELECT * FROM artworks WHERE artist_id = ?', [artistId], cb);
+}
+
+function updateArtworkCollection(id, collectionId, cb) {
+  db.run('UPDATE artworks SET collection_id = ? WHERE id = ?', [collectionId, id], cb);
+}
+
+module.exports = { getArtwork, getArtworksByArtist, updateArtworkCollection };

--- a/models/collectionModel.js
+++ b/models/collectionModel.js
@@ -1,0 +1,16 @@
+const { db } = require('./db');
+
+function createCollection(name, artistId, slug, cb) {
+  const stmt = `INSERT INTO collections (name, artist_id, slug) VALUES (?,?,?)`;
+  db.run(stmt, [name, artistId, slug], cb);
+}
+
+function getCollectionsByArtist(artistId, cb) {
+  db.all('SELECT * FROM collections WHERE artist_id = ?', [artistId], cb);
+}
+
+function updateCollection(id, name, cb) {
+  db.run('UPDATE collections SET name = ? WHERE id = ?', [name, id], cb);
+}
+
+module.exports = { createCollection, getCollectionsByArtist, updateCollection };

--- a/models/db.js
+++ b/models/db.js
@@ -56,6 +56,24 @@ function initialize() {
       logo TEXT
     )`);
 
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      display_name TEXT,
+      username TEXT UNIQUE,
+      password TEXT,
+      role TEXT,
+      promo_code TEXT
+    )`);
+    db.run('ALTER TABLE users ADD COLUMN role TEXT', () => {});
+    db.run('ALTER TABLE users ADD COLUMN promo_code TEXT', () => {});
+
+    db.run(`CREATE TABLE IF NOT EXISTS collections (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT,
+      artist_id TEXT,
+      slug TEXT
+    )`);
+
     db.run(`CREATE TABLE IF NOT EXISTS artworks (
       id TEXT PRIMARY KEY,
       artist_id TEXT,
@@ -80,6 +98,7 @@ function initialize() {
     db.run('ALTER TABLE artworks ADD COLUMN featured INTEGER DEFAULT 0', () => {});
     db.run('ALTER TABLE artworks ADD COLUMN isVisible INTEGER DEFAULT 1', () => {});
     db.run('ALTER TABLE artworks ADD COLUMN isFeatured INTEGER DEFAULT 0', () => {});
+    db.run('ALTER TABLE artworks ADD COLUMN collection_id INTEGER', () => {});
 
     db.get('SELECT COUNT(*) as count FROM galleries', (err, row) => {
       if (err) return;

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -1,0 +1,14 @@
+const { db } = require('./db');
+
+function createUser(displayName, username, password, role, promoCode, cb) {
+  const stmt = `INSERT INTO users (display_name, username, password, role, promo_code) VALUES (?,?,?,?,?)`;
+  db.run(stmt, [displayName, username, password, role, promoCode], function(err) {
+    if (cb) cb(err, this ? this.lastID : null);
+  });
+}
+
+function findUserByUsername(username, cb) {
+  db.get('SELECT * FROM users WHERE username = ?', [username], cb);
+}
+
+module.exports = { createUser, findUserByUsername };

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -14,7 +14,7 @@
       </div>
     </nav>
   <main class="max-w-4xl mx-auto p-6">
-    <h1 class="text-3xl font-bold mb-8 text-center">Admin Dashboard</h1>
+    <h1 class="text-3xl font-bold mb-8 text-center"><%= user && user.role ? (user.role.charAt(0).toUpperCase() + user.role.slice(1)) : 'Admin' %> Dashboard</h1>
     <div class="grid grid-cols-1 sm:grid-cols-4 gap-6">
       <a href="/dashboard/galleries" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">
         <svg class="w-8 h-8 md:w-6 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h18M3 17h18"/></svg>

--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Artist Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex gap-4 mt-2 md:mt-0">
+      <span class="font-semibold"><%= user.role %></span>
+      <a href="/logout" class="hover:underline">Logout</a>
+    </div>
+  </nav>
+  <main class="max-w-4xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-6 text-center"><%= user.role.charAt(0).toUpperCase() + user.role.slice(1) %> Dashboard</h1>
+    <section class="mb-8">
+      <h2 class="text-xl font-semibold mb-4">Collections</h2>
+      <ul class="space-y-4">
+        <% collections.forEach(c => { %>
+          <li>
+            <form method="POST" action="/dashboard/artist/collections/<%= c.id %>" class="flex gap-2 items-center">
+              <input type="text" name="name" value="<%= c.name %>" class="border border-gray-300 rounded px-2 py-1 flex-grow">
+              <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded">Save</button>
+            </form>
+          </li>
+        <% }) %>
+      </ul>
+      <form method="POST" action="/dashboard/artist/collections" class="mt-6 flex gap-2 items-center">
+        <input type="text" name="name" placeholder="New collection" class="border border-gray-300 rounded px-2 py-1 flex-grow" required>
+        <button type="submit" class="bg-green-600 text-white px-3 py-1 rounded">Add</button>
+      </form>
+    </section>
+    <section>
+      <h2 class="text-xl font-semibold mb-4">Artworks</h2>
+      <% artworks.forEach(a => { %>
+        <div class="mb-4 p-4 border rounded">
+          <div class="font-medium mb-2"><%= a.title %></div>
+          <form method="POST" action="/dashboard/artist/artworks/<%= a.id %>/collection" class="flex gap-2 items-center">
+            <select name="collection_id" class="border border-gray-300 rounded px-2 py-1 flex-grow">
+              <option value="">No Collection</option>
+              <% collections.forEach(c => { %>
+                <option value="<%= c.id %>" <%= a.collection_id === c.id ? 'selected' : '' %>><%= c.name %></option>
+              <% }) %>
+            </select>
+            <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded">Assign</button>
+          </form>
+        </div>
+      <% }) %>
+    </section>
+  </main>
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+</body>
+</html>

--- a/views/dashboard/gallery.ejs
+++ b/views/dashboard/gallery.ejs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Gallery Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex gap-4 mt-2 md:mt-0">
+      <span class="font-semibold"><%= user.role %></span>
+      <a href="/logout" class="hover:underline">Logout</a>
+    </div>
+  </nav>
+  <main class="max-w-4xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-6 text-center"><%= user.role.charAt(0).toUpperCase() + user.role.slice(1) %> Dashboard</h1>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+      <a href="/dashboard/galleries" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">Manage Galleries</a>
+      <a href="/dashboard/artists" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">Manage Artists</a>
+      <a href="/dashboard/artworks" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">Manage Artworks</a>
+      <a href="/dashboard/settings" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">Gallery Settings</a>
+    </div>
+  </main>
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+</body>
+</html>

--- a/views/signup/artist.ejs
+++ b/views/signup/artist.ejs
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Artist Signup</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex gap-4 mt-2 md:mt-0">
+      <a href="/signup/artist" class="hover:underline">Artist Signup</a>
+      <a href="/signup/gallery" class="hover:underline">Gallery Signup</a>
+    </div>
+  </nav>
+  <main class="max-w-sm mx-auto p-6">
+    <div class="bg-white border border-gray-200 p-6 rounded shadow">
+      <h1 class="text-xl mb-4 text-center">Artist Signup</h1>
+      <% if (flash.error && flash.error.length) { %>
+        <p class="text-red-600 mb-4"><%= flash.error[0] %></p>
+      <% } %>
+      <form method="POST" action="/signup/artist" class="space-y-4">
+        <div>
+          <label class="block text-sm font-medium" for="display_name">Display Name</label>
+          <input id="display_name" type="text" name="display_name" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="username">Username</label>
+          <input id="username" type="text" name="username" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="password">Password</label>
+          <input id="password" type="password" name="password" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="passcode">Passcode</label>
+          <input id="passcode" type="text" name="passcode" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded text-base">Sign Up</button>
+      </form>
+    </div>
+  </main>
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+</body>
+</html>

--- a/views/signup/gallery.ejs
+++ b/views/signup/gallery.ejs
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Gallery Signup</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex gap-4 mt-2 md:mt-0">
+      <a href="/signup/artist" class="hover:underline">Artist Signup</a>
+      <a href="/signup/gallery" class="hover:underline">Gallery Signup</a>
+    </div>
+  </nav>
+  <main class="max-w-sm mx-auto p-6">
+    <div class="bg-white border border-gray-200 p-6 rounded shadow">
+      <h1 class="text-xl mb-4 text-center">Gallery Signup</h1>
+      <% if (flash.error && flash.error.length) { %>
+        <p class="text-red-600 mb-4"><%= flash.error[0] %></p>
+      <% } %>
+      <form method="POST" action="/signup/gallery" class="space-y-4">
+        <div>
+          <label class="block text-sm font-medium" for="display_name">Gallery Name</label>
+          <input id="display_name" type="text" name="display_name" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="username">Username</label>
+          <input id="username" type="text" name="username" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="password">Password</label>
+          <input id="password" type="password" name="password" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="passcode">Passcode</label>
+          <input id="passcode" type="text" name="passcode" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+        </div>
+        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded text-base">Sign Up</button>
+      </form>
+    </div>
+  </main>
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support artist and gallery signups with promo code validation
- add collections and user role handling in dashboard
- show user role headers across dashboards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f60892d40832098e6ae2494e37348