### PR TITLE
Apply demo auth before dashboard routes and test

### DIFF
--- a/routes/dashboard/admin.js
+++ b/routes/dashboard/admin.js
@@ -12,13 +12,6 @@ try {
 
 const { db } = require('../../models/db');
 
-function simulateAuth(req, res, next) {
-  if (!req.session.user) {
-    req.session.user = { username: 'demoAdmin', role: 'admin' };
-  }
-  next();
-}
-
 function requireLogin(req, res, next) {
   if (req.user) return next();
   res.redirect('/login');
@@ -90,11 +83,6 @@ async function processImages(file) {
 router.get('/gallery', requireRole('gallery'), (req, res) => {
   res.render('dashboard/gallery', { user: req.session.user });
 });
-
-// Apply fake authentication for admin routes when enabled
-if (process.env.USE_DEMO_AUTH === 'true') {
-  router.use(simulateAuth);
-}
 
 // Admin dashboard
 router.get('/', requireRole('admin'), (req, res) => {

--- a/server.js
+++ b/server.js
@@ -29,6 +29,19 @@ try {
 const csrf = require('./middleware/csrf');
 const { initialize } = require('./models/db');
 
+function simulateAuth(req, res, next) {
+  if (!req.session.user) {
+    if (req.path === '/artist' || req.path.startsWith('/artist/')) {
+      req.session.user = { username: 'demoArtist', role: 'artist', id: 'artist1' };
+    } else if (req.path.startsWith('/gallery')) {
+      req.session.user = { username: 'demoGallery', role: 'gallery' };
+    } else {
+      req.session.user = { username: 'demoAdmin', role: 'admin' };
+    }
+  }
+  next();
+}
+
 // Read session secret from environment variables with development-friendly default
 const SESSION_SECRET = process.env.SESSION_SECRET || 'gallerysecret';
 
@@ -61,6 +74,9 @@ app.use(csrfProtection);
 
 // Flash messages using connect-flash or fallback implementation
 app.use(flash());
+if (process.env.USE_DEMO_AUTH === 'true') {
+  app.use('/dashboard', simulateAuth);
+}
 app.use((req, res, next) => {
   req.user = req.session.user;
   res.locals.user = req.user;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -413,3 +413,31 @@ test('authenticated upload stores file, DB entry, and is served', async () => {
   assert.strictEqual(fileRes.statusCode, 200);
   fs.unlinkSync(path.join(uploadsDir, standard));
 });
+
+test('demo auth grants access to dashboard routes without login', async () => {
+  process.env.USE_DEMO_AUTH = 'true';
+  delete require.cache[require.resolve('../server')];
+  const demoApp = require('../server');
+  const demoServer = await new Promise(resolve => {
+    const s = demoApp.listen(0, () => resolve(s));
+  });
+  const port = demoServer.address().port;
+
+  const routes = [
+    '/dashboard',
+    '/dashboard/galleries',
+    '/dashboard/artists',
+    '/dashboard/artworks',
+    '/dashboard/upload',
+    '/dashboard/artist'
+  ];
+
+  for (const r of routes) {
+    const res = await httpGet(`http://localhost:${port}${r}`);
+    assert.strictEqual(res.statusCode, 200);
+  }
+
+  await new Promise(resolve => demoServer.close(resolve));
+  delete require.cache[require.resolve('../server')];
+  process.env.USE_DEMO_AUTH = 'false';
+});


### PR DESCRIPTION
## Summary
- Move demo authentication middleware to run before all `/dashboard` routes and assign roles based on subpath.
- Remove route-level demo auth from admin router.
- Add regression tests ensuring `USE_DEMO_AUTH=true` grants dashboard access without login.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f6a1928d48320adde512dd6399c93