### PR TITLE
Add signup navigation and chooser

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -29,6 +29,10 @@ function signupHandler(role) {
   };
 }
 
+router.get('/signup', (req, res) => {
+  res.render('signup/index');
+});
+
 router.get('/signup/artist', (req, res) => {
   res.render('signup/artist');
 });

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -8,10 +8,11 @@
 <body class="font-sans bg-white text-black">
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex gap-4 mt-2 md:mt-0">
-      <a href="/demo-gallery" class="hover:underline">Demo Gallery</a>
-      <a href="/login" class="hover:underline">Admin</a>
-    </div>
+      <div class="flex gap-4 mt-2 md:mt-0">
+        <a href="/demo-gallery" class="hover:underline">Demo Gallery</a>
+        <a href="/login" class="hover:underline">Login</a>
+        <a href="/signup" class="hover:underline">Sign Up</a>
+      </div>
   </nav>
 
   <section class="text-center py-16 px-4">
@@ -19,8 +20,8 @@
     <p class="text-base text-gray-600 mb-8">Multi-gallery platform for managing and showcasing fine art.</p>
     <div class="flex justify-center gap-4 flex-wrap">
       <a href="#galleries" class="bg-black text-white px-6 py-3 rounded hover:bg-gray-800">View a Gallery</a>
-      <a href="/login" class="border border-black px-6 py-3 rounded hover:bg-gray-100">Create Your Own</a>
-    </div>
+        <a href="/signup" class="border border-black px-6 py-3 rounded hover:bg-gray-100">Create Your Own</a>
+      </div>
   </section>
 
   <section id="galleries" class="max-w-4xl mx-auto px-4 py-12">

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -8,10 +8,11 @@
 <body class="font-sans bg-white text-black">
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex gap-4 mt-2 md:mt-0">
-      <a href="/demo-gallery" class="hover:underline">Demo Gallery</a>
-      <a href="/login" class="hover:underline">Admin</a>
-    </div>
+      <div class="flex gap-4 mt-2 md:mt-0">
+        <a href="/demo-gallery" class="hover:underline">Demo Gallery</a>
+        <a href="/login" class="hover:underline">Login</a>
+        <a href="/signup" class="hover:underline">Sign Up</a>
+      </div>
   </nav>
   <main class="max-w-sm mx-auto p-6">
     <div class="bg-white border border-gray-200 p-6 rounded shadow">
@@ -31,9 +32,13 @@
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded text-base">Login</button>
       </form>
-      <p class="mt-4 text-center"><a href="/" class="text-blue-600 underline">Back home</a></p>
-    </div>
-  </main>
+        <p class="mt-4 text-center">
+          New here? <a href="/signup/artist" class="text-blue-600 underline">Sign up as Artist</a>
+          or <a href="/signup/gallery" class="text-blue-600 underline">Sign up as Gallery</a>
+        </p>
+        <p class="mt-4 text-center"><a href="/" class="text-blue-600 underline">Back home</a></p>
+      </div>
+    </main>
   <footer class="text-center py-6 border-t border-gray-200 mt-12">
     <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
   </footer>

--- a/views/signup/index.ejs
+++ b/views/signup/index.ejs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Sign Up</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+    <div class="flex gap-4 mt-2 md:mt-0">
+      <a href="/signup/artist" class="hover:underline">Artist Signup</a>
+      <a href="/signup/gallery" class="hover:underline">Gallery Signup</a>
+    </div>
+  </nav>
+  <main class="max-w-2xl mx-auto p-6 text-center">
+    <h1 class="text-xl mb-6">Choose your signup</h1>
+    <div class="flex justify-center gap-4 flex-wrap">
+      <a href="/signup/artist" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded text-base">Sign up as Artist</a>
+      <a href="/signup/gallery" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded text-base">Sign up as Gallery</a>
+    </div>
+  </main>
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Link home page and nav bars to a new signup chooser page
- Add prominent artist and gallery signup links on the login page
- Provide a signup chooser view and route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f744c7c648320b50106db718046f1