### PR TITLE
Make dashboard links role-aware

### DIFF
--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -7,14 +7,9 @@
   <meta name="csrf-token" content="<%= csrfToken %>">
 </head>
 <body class="font-sans bg-white text-black">
-  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex space-x-4 mt-2 md:mt-0">
-      <a href="/dashboard" class="hover:underline">Dashboard</a>
-      <a href="/logout" class="hover:underline">Logout</a>
-    </div>
-  </nav>
-  <main class="max-w-3xl mx-auto p-6">
+    <%- include('../partials/navbar'); %>
+    <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
+    <main class="max-w-3xl mx-auto p-6">
     <div class="border border-gray-200 p-6 rounded shadow">
       <h1 class="text-2xl mb-4 text-center">Artist Management</h1>
       <% if (flash.error && flash.error.length) { %>
@@ -82,7 +77,7 @@
           </li>
         <% }) %>
       </ul>
-      <p class="mt-6"><a href="/dashboard" class="text-blue-600 underline">Back to dashboard</a></p>
+        <p class="mt-6"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
   <footer class="text-center py-6 border-t border-gray-200 mt-12">

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -7,14 +7,9 @@
   <meta name="csrf-token" content="<%= csrfToken %>">
 </head>
 <body class="font-sans bg-white text-black">
-  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex space-x-4 mt-2 md:mt-0">
-      <a href="/dashboard" class="hover:underline">Dashboard</a>
-      <a href="/logout" class="hover:underline">Logout</a>
-    </div>
-  </nav>
-  <main class="max-w-3xl mx-auto p-6">
+    <%- include('../partials/navbar'); %>
+    <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
+    <main class="max-w-3xl mx-auto p-6">
     <div class="border border-gray-200 p-6 rounded shadow">
       <h1 class="text-2xl mb-4 text-center">Artwork Management</h1>
       <% if (flash.error && flash.error.length) { %>
@@ -139,7 +134,7 @@
           </li>
         <% }) %>
       </ul>
-      <p class="mt-6"><a href="/dashboard" class="text-blue-600 underline">Back to dashboard</a></p>
+        <p class="mt-6"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
   <footer class="text-center py-6 border-t border-gray-200 mt-12">

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -6,14 +6,8 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="font-sans bg-white text-black">
-    <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-      <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-      <div class="flex gap-4 mt-2 md:mt-0">
-        <a href="/dashboard" class="hover:underline">Dashboard</a>
-        <a href="/logout" class="hover:underline">Logout</a>
-      </div>
-    </nav>
-  <main class="max-w-4xl mx-auto p-6">
+      <%- include('../partials/navbar'); %>
+    <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-8 text-center"><%= user && user.role ? (user.role.charAt(0).toUpperCase() + user.role.slice(1)) : 'Admin' %> Dashboard</h1>
     <div class="grid grid-cols-1 sm:grid-cols-4 gap-6">
       <a href="/dashboard/galleries" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">

--- a/views/admin/galleries.ejs
+++ b/views/admin/galleries.ejs
@@ -7,14 +7,9 @@
   <meta name="csrf-token" content="<%= csrfToken %>">
 </head>
 <body class="font-sans bg-white text-black">
-  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex space-x-4 mt-2 md:mt-0">
-      <a href="/dashboard" class="hover:underline">Dashboard</a>
-      <a href="/logout" class="hover:underline">Logout</a>
-    </div>
-  </nav>
-  <main class="max-w-3xl mx-auto p-6">
+    <%- include('../partials/navbar'); %>
+    <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
+    <main class="max-w-3xl mx-auto p-6">
     <div class="border border-gray-200 p-6 rounded shadow">
       <h1 class="text-2xl mb-4 text-center">Gallery Management</h1>
       <% if (flash.error && flash.error.length) { %>
@@ -60,7 +55,7 @@
           </li>
         <% }) %>
       </ul>
-      <p class="mt-6"><a href="/dashboard" class="text-blue-600 underline">Back to dashboard</a></p>
+        <p class="mt-6"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
   <footer class="text-center py-6 border-t border-gray-200 mt-12">

--- a/views/admin/settings.ejs
+++ b/views/admin/settings.ejs
@@ -6,14 +6,9 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="font-sans bg-white text-black">
-  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex space-x-4 mt-2 md:mt-0">
-      <a href="/dashboard" class="hover:underline">Dashboard</a>
-      <a href="/logout" class="hover:underline">Logout</a>
-    </div>
-  </nav>
-  <main class="max-w-xl mx-auto p-6">
+    <%- include('../partials/navbar'); %>
+    <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
+    <main class="max-w-xl mx-auto p-6">
     <div class="border border-gray-200 p-6 rounded shadow">
       <h1 class="text-2xl mb-4 text-center">Gallery Settings</h1>
       <% if (flash.error && flash.error.length) { %>
@@ -62,7 +57,7 @@
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Save</button>
       </form>
-      <p class="mt-6 text-center"><a href="/dashboard" class="text-blue-600 underline">Back to dashboard</a></p>
+        <p class="mt-6 text-center"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
   <footer class="text-center py-6 border-t border-gray-200 mt-12">

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -7,14 +7,8 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="font-sans bg-white text-black">
-  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex space-x-4 mt-2 md:mt-0">
-      <a href="/dashboard" class="hover:underline">Dashboard</a>
-      <a href="/logout" class="hover:underline">Logout</a>
-    </div>
-  </nav>
-  <main class="max-w-lg mx-auto p-6">
+    <%- include('../partials/navbar'); %>
+    <main class="max-w-lg mx-auto p-6">
     <div class="border border-gray-200 p-6 rounded shadow">
       <h1 class="text-2xl mb-4 text-center">Upload Artwork</h1>
       <% if (flash.error && flash.error.length) { %>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -1,7 +1,7 @@
 <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
   <a href="/" class="text-2xl font-bold">FineArtSuite</a>
   <div class="flex gap-4 mt-2 md:mt-0">
-    <a href="<%= user && user.role === 'artist' ? '/dashboard/artist' : '/dashboard' %>" class="hover:underline">Dashboard</a>
+    <a href="<%= user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard' %>" class="hover:underline">Dashboard</a>
     <% if (user && user.role !== 'artist') { %>
       <a href="/dashboard/galleries" class="hover:underline">Galleries</a>
       <a href="/dashboard/artists" class="hover:underline">Artists</a>


### PR DESCRIPTION
## Summary
- Route Dashboard link based on user role in shared navbar
- Replace hard-coded dashboard URLs in admin templates with role-aware navbar and links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f8b6142f08320812a8c13d011f28b