### PR TITLE
Randomize artist avatars

### DIFF
--- a/models/db.js
+++ b/models/db.js
@@ -2,6 +2,7 @@ const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const fs = require('fs');
 const bcrypt = require('../utils/bcrypt');
+const randomAvatar = require('../utils/avatar');
 
 const db = new sqlite3.Database(path.join(__dirname, '..', 'gallery.db'));
 
@@ -142,13 +143,13 @@ function seed(done) {
     { slug: 'city-gallery', name: 'City Gallery', bio: 'Featuring modern works from local artists.' }
   ];
   const artists = [
-    { id: 'artist1', gallery_slug: 'demo-gallery', name: 'Jane Doe', bio: 'An abstract artist exploring color and form.', bioImageUrl: 'https://picsum.photos/id/360/150/150', fullBio: 'Jane Doe investigates the emotional resonance of color and shape.\n\nHer canvases challenge viewers to find their own narratives within abstract forms.' },
-    { id: 'artist2', gallery_slug: 'demo-gallery', name: 'John Smith', bio: 'Exploring the geometry of urban life.', bioImageUrl: 'https://picsum.photos/id/361/150/150', fullBio: 'John Smith captures cityscapes through precise lines and bold structure.\n\nHis work reflects the tension between order and chaos in metropolitan spaces.' },
-    { id: 'artist3', gallery_slug: 'demo-gallery', name: 'Emily Carter', bio: 'Mixed media artist inspired by nature.', bioImageUrl: 'https://picsum.photos/id/362/150/150', fullBio: 'Emily Carter combines found objects and paint to evoke forest serenity.\n\nHer layered textures invite close inspection and contemplation.' },
-    { id: 'artist4', gallery_slug: 'demo-gallery', name: 'Liam Nguyen', bio: 'Digital artist focusing on surreal landscapes.', bioImageUrl: 'https://picsum.photos/id/363/150/150', fullBio: 'Liam Nguyen crafts dreamlike vistas with a digital brush.\n\nHe blends reality and imagination to transport viewers beyond the ordinary.' },
-    { id: 'artist5', gallery_slug: 'city-gallery', name: 'Sophia Martinez', bio: 'Sculptor merging modern and classical motifs.', bioImageUrl: 'https://picsum.photos/id/364/150/150', fullBio: 'Sophia Martinez merges historical influences with contemporary design.\n\nHer sculptures echo timeless narratives through modern materials.' },
-    { id: 'artist6', gallery_slug: 'city-gallery', name: 'Luca Green', bio: 'Painter capturing urban life with bold colors.', bioImageUrl: 'https://picsum.photos/id/365/150/150', fullBio: 'Luca Green paints bustling streets with vibrant energy.\n\nHis dynamic brushwork celebrates the rhythm of city living.' },
-    { id: 'artist7', gallery_slug: 'city-gallery', name: 'Ava Patel', bio: 'Digital artist blending technology and emotion.', bioImageUrl: 'https://picsum.photos/id/366/150/150', fullBio: 'Ava Patel explores human connection through digital mediums.\n\nHer creations blur the line between code and compassion.' }
+    { id: 'artist1', gallery_slug: 'demo-gallery', name: 'Jane Doe', bio: 'An abstract artist exploring color and form.', bioImageUrl: randomAvatar(), fullBio: 'Jane Doe investigates the emotional resonance of color and shape.\n\nHer canvases challenge viewers to find their own narratives within abstract forms.' },
+    { id: 'artist2', gallery_slug: 'demo-gallery', name: 'John Smith', bio: 'Exploring the geometry of urban life.', bioImageUrl: randomAvatar(), fullBio: 'John Smith captures cityscapes through precise lines and bold structure.\n\nHis work reflects the tension between order and chaos in metropolitan spaces.' },
+    { id: 'artist3', gallery_slug: 'demo-gallery', name: 'Emily Carter', bio: 'Mixed media artist inspired by nature.', bioImageUrl: randomAvatar(), fullBio: 'Emily Carter combines found objects and paint to evoke forest serenity.\n\nHer layered textures invite close inspection and contemplation.' },
+    { id: 'artist4', gallery_slug: 'demo-gallery', name: 'Liam Nguyen', bio: 'Digital artist focusing on surreal landscapes.', bioImageUrl: randomAvatar(), fullBio: 'Liam Nguyen crafts dreamlike vistas with a digital brush.\n\nHe blends reality and imagination to transport viewers beyond the ordinary.' },
+    { id: 'artist5', gallery_slug: 'city-gallery', name: 'Sophia Martinez', bio: 'Sculptor merging modern and classical motifs.', bioImageUrl: randomAvatar(), fullBio: 'Sophia Martinez merges historical influences with contemporary design.\n\nHer sculptures echo timeless narratives through modern materials.' },
+    { id: 'artist6', gallery_slug: 'city-gallery', name: 'Luca Green', bio: 'Painter capturing urban life with bold colors.', bioImageUrl: randomAvatar(), fullBio: 'Luca Green paints bustling streets with vibrant energy.\n\nHis dynamic brushwork celebrates the rhythm of city living.' },
+    { id: 'artist7', gallery_slug: 'city-gallery', name: 'Ava Patel', bio: 'Digital artist blending technology and emotion.', bioImageUrl: randomAvatar(), fullBio: 'Ava Patel explores human connection through digital mediums.\n\nHer creations blur the line between code and compassion.' }
   ];
 
   const galleryStmt = db.prepare('INSERT INTO galleries (slug, name, bio) VALUES (?,?,?)');

--- a/routes/dashboard/admin.js
+++ b/routes/dashboard/admin.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const path = require('path');
 const fs = require('fs');
 const multer = require('multer');
+const randomAvatar = require('../../utils/avatar');
 let Jimp;
 try {
   Jimp = require('jimp');
@@ -255,8 +256,9 @@ router.post('/artists', requireRole('admin', 'gallery'), (req, res) => {
       req.flash('error', 'All fields are required');
       return res.redirect('/dashboard/artists');
     }
+    const avatarUrl = bioImageUrl || randomAvatar();
     const stmt = 'INSERT INTO artists (id, gallery_slug, name, bio, fullBio, bioImageUrl) VALUES (?,?,?,?,?,?)';
-    db.run(stmt, [id, gallery_slug, name, bio, fullBio || '', bioImageUrl || ''], err => {
+    db.run(stmt, [id, gallery_slug, name, bio, fullBio || '', avatarUrl], err => {
       if (err) {
         console.error(err);
         req.flash('error', 'Database error');
@@ -285,8 +287,9 @@ router.put('/artists/:id', requireRole('admin', 'gallery'), async (req, res) => 
       }
     }
     const { name, bio, fullBio, bioImageUrl, gallery_slug } = req.body;
+    const avatarUrl = bioImageUrl || randomAvatar();
     let stmt = 'UPDATE artists SET name = ?, bio = ?, fullBio = ?, bioImageUrl = ?';
-    const params = [name, bio, fullBio || '', bioImageUrl || ''];
+    const params = [name, bio, fullBio || '', avatarUrl];
     if (req.user.role === 'admin' && gallery_slug) {
       stmt += ', gallery_slug = ?';
       params.push(gallery_slug);

--- a/utils/avatar.js
+++ b/utils/avatar.js
@@ -1,0 +1,7 @@
+function randomAvatar() {
+  const id = Math.floor(Math.random() * (70 - 15 + 1)) + 15; // 15-70 inclusive
+  return `https://avatar.iran.liara.run/public/${id}`;
+}
+
+module.exports = randomAvatar;
+


### PR DESCRIPTION
## Summary
- add helper to generate random avatar URLs
- seed artists and dashboard endpoints now use randomized avatar images by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f8dc326848320b34fc0d7fd2754d9