### PR TITLE
feat: allow artist photo upload

### DIFF
--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -18,7 +18,7 @@
       <% if (flash.success && flash.success.length) { %>
         <p class="text-green-600 mb-4"><%= flash.success[0] %></p>
       <% } %>
-      <form id="add-artist" method="post" action="/dashboard/artists" class="space-y-4">
+      <form id="add-artist" method="post" action="/dashboard/artists" enctype="multipart/form-data" class="space-y-4">
         <div>
           <label class="block text-sm font-medium" for="id">Artist ID</label>
           <input id="id" type="text" name="id" value="<%= generatedId %>" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1 bg-gray-100">
@@ -46,6 +46,10 @@
         <div>
           <label class="block text-sm font-medium" for="bioImageUrl">Artist Portrait URL</label>
           <input id="bioImageUrl" type="text" name="bioImageUrl" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
+        </div>
+        <div>
+          <label class="block text-sm font-medium" for="bioImageFile">Or Upload Portrait</label>
+          <input id="bioImageFile" type="file" name="bioImageFile" accept="image/*" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
         </div>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button type="submit" class="save-btn bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center justify-center">
@@ -94,12 +98,12 @@
       const original = label.textContent;
       btn.disabled = true;
       label.innerHTML = `<svg class="animate-spin h-4 w-4 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>Saving…`;
-      const data = Object.fromEntries(new FormData(addForm).entries());
+      const formData = new FormData(addForm);
       try {
         const res = await fetch('/dashboard/artists', {
           method: 'POST',
-          headers: { 'Content-Type':'application/json', 'CSRF-Token': csrfToken },
-          body: JSON.stringify(data)
+          headers: { 'CSRF-Token': csrfToken },
+          body: formData
         });
         if (!res.ok) {
           const errText = await res.text();


### PR DESCRIPTION
## Summary
- support uploading an artist portrait when creating profiles
- allow admin form to send multipart data for portrait uploads
- restore placeholder for uploads directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f8f63561083208244c67177a10f15