### PR TITLE
Allow linking or uploading artwork images

### DIFF
--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -121,17 +121,23 @@ router.post('/artworks', requireRole('artist'), (req, res) => {
       req.flash('error', err.message);
       return res.redirect('/dashboard/artist');
     }
-    const { title, medium, dimensions, price } = req.body;
+    const { title, medium, dimensions, price, imageUrl } = req.body;
     if (!title || !medium || !dimensions) {
       req.flash('error', 'All fields are required');
       return res.redirect('/dashboard/artist');
     }
-    if (!req.file) {
+    if (req.file && imageUrl) {
+      req.flash('error', 'Choose either an upload or a URL');
+      return res.redirect('/dashboard/artist');
+    }
+    if (!req.file && !imageUrl) {
       req.flash('error', 'Image is required');
       return res.redirect('/dashboard/artist');
     }
     try {
-      const images = await processImages(req.file);
+      const images = req.file
+        ? await processImages(req.file)
+        : { imageFull: imageUrl, imageStandard: imageUrl, imageThumb: imageUrl };
       createArtwork(req.session.user.id, title, medium, dimensions, price, images, createErr => {
         if (createErr) {
           console.error(createErr);

--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -36,7 +36,9 @@
         <input type="text" name="medium" placeholder="Medium" required class="border border-gray-300 rounded px-2 py-1 w-full">
         <input type="text" name="dimensions" placeholder="Dimensions" required class="border border-gray-300 rounded px-2 py-1 w-full">
         <input type="text" name="price" placeholder="Price" class="border border-gray-300 rounded px-2 py-1 w-full">
-        <input type="file" name="imageFile" accept="image/*" required class="border border-gray-300 rounded px-2 py-1 w-full">
+        <input type="file" name="imageFile" accept="image/*" class="border border-gray-300 rounded px-2 py-1 w-full">
+        <input type="url" name="imageUrl" placeholder="Image URL" class="border border-gray-300 rounded px-2 py-1 w-full">
+        <p class="text-xs text-gray-500">Provide an image file or a URL</p>
         <button type="submit" class="bg-green-600 text-white px-3 py-1 rounded">Upload</button>
       </form>
       <% artworks.forEach(a => { %>

--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -18,7 +18,7 @@
               <span class="flex-1"><span class="font-semibold"><%= art.artist_name %></span> - <%= art.title %></span>
             </button>
             <div class="art-form-wrapper max-h-0 opacity-0 overflow-hidden transition-all ease-in-out">
-              <form class="p-4 space-y-2 art-form" data-id="<%= art.id %>">
+              <form class="p-4 space-y-2 art-form" data-id="<%= art.id %>" enctype="multipart/form-data">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                 <label class="block text-sm font-medium">Title
                   <input name="title" value="<%= art.title %>" class="mt-1 w-full border rounded px-2 py-1"/>
@@ -45,6 +45,13 @@
                   <% }) %>
                 </select>
               </label>
+              <label class="block text-sm font-medium">Replace Image
+                <input type="file" name="imageFile" accept="image/*" class="mt-1 w-full border rounded px-2 py-1"/>
+              </label>
+              <label class="block text-sm font-medium">Image URL
+                <input type="url" name="imageUrl" class="mt-1 w-full border rounded px-2 py-1"/>
+              </label>
+              <p class="text-xs text-gray-500">Choose either an upload or a URL</p>
               <label class="flex items-center gap-2 text-sm">
                 <input type="checkbox" name="isVisible" value="1" <%= art.isVisible ? 'checked' : '' %>>
                 Visible
@@ -63,7 +70,7 @@
         <span class="font-semibold flex-1">Untitled</span>
       </button>
       <div class="art-form-wrapper max-h-0 opacity-0 overflow-hidden transition-all ease-in-out">
-        <form class="p-4 space-y-2 art-form" data-id="<%= generatedId %>" data-new="true">
+        <form class="p-4 space-y-2 art-form" data-id="<%= generatedId %>" data-new="true" enctype="multipart/form-data">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
           <label class="block text-sm font-medium">Title
             <input name="title" class="mt-1 w-full border rounded px-2 py-1"/>
@@ -90,6 +97,13 @@
               <% }) %>
             </select>
           </label>
+          <label class="block text-sm font-medium">Image File
+            <input type="file" name="imageFile" accept="image/*" class="mt-1 w-full border rounded px-2 py-1"/>
+          </label>
+          <label class="block text-sm font-medium">Image URL
+            <input type="url" name="imageUrl" class="mt-1 w-full border rounded px-2 py-1"/>
+          </label>
+          <p class="text-xs text-gray-500">Provide an image file or a URL</p>
           <label class="flex items-center gap-2 text-sm">
             <input type="checkbox" name="isVisible" value="1" checked>
             Visible


### PR DESCRIPTION
## Summary
- Let artists create artwork using either an uploaded image or an image URL.
- Add image file and URL inputs to artist dashboard form.
- Extend dashboard artwork forms to upload or link images when adding or editing.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f90b1404c83208c7700d0fede1bc6