### PR TITLE
Unify gallery settings and galleries management

### DIFF
--- a/models/db.js
+++ b/models/db.js
@@ -34,18 +34,6 @@ function initialize() {
       gallery_id TEXT
     )`);
 
-    db.run(`CREATE TABLE IF NOT EXISTS gallery_settings (
-      id INTEGER PRIMARY KEY CHECK (id = 1),
-      name TEXT,
-      slug TEXT,
-      phone TEXT,
-      email TEXT,
-      address TEXT,
-      description TEXT,
-      owner TEXT,
-      logo TEXT
-    )`);
-
     db.run(`CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       display_name TEXT,

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -22,10 +22,6 @@
         <svg class="w-8 h-8 md:w-6 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-8h6m-6 4h6m-6 4h2"></path></svg>
         <span class="mt-2 font-semibold">Artworks</span>
       </a>
-      <a href="/dashboard/settings" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">
-        <svg class="w-8 h-8 md:w-6 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l.7 2.15a1 1 0 00.95.69h2.262c.969 0 1.371 1.24.588 1.81l-1.834 1.333a1 1 0 00-.364 1.118l.7 2.15c.3.921-.755 1.688-1.538 1.118L12 11.347l-1.915 1.42c-.783.57-1.838-.197-1.538-1.118l.7-2.15a1 1 0 00-.364-1.118L7.049 7.577c-.783-.57-.38-1.81.588-1.81h2.262a1 1 0 00.95-.69l.7-2.15z"></path></svg>
-        <span class="mt-2 font-semibold">Settings</span>
-      </a>
     </div>
     <div class="text-center mt-8">
       <a href="/logout" class="text-sm text-gray-600 underline">Logout</a>

--- a/views/admin/galleries.ejs
+++ b/views/admin/galleries.ejs
@@ -26,7 +26,7 @@
               <span class="font-semibold flex-1"><%= g.name %></span>
             </button>
             <div class="gallery-form-wrapper max-h-0 opacity-0 overflow-hidden transition-all ease-in-out">
-              <form class="p-4 space-y-2 gallery-form" data-slug="<%= g.slug %>">
+              <form class="p-4 space-y-2 gallery-form" data-slug="<%= g.slug %>" enctype="multipart/form-data">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                 <label class="block text-sm font-medium">Slug
                   <input name="slug" value="<%= g.slug %>" class="mt-1 w-full border rounded px-2 py-1"/>
@@ -34,8 +34,26 @@
                 <label class="block text-sm font-medium">Name
                   <input name="name" value="<%= g.name %>" class="mt-1 w-full border rounded px-2 py-1"/>
                 </label>
-                <label class="block text-sm font-medium">Bio
-                  <textarea name="bio" rows="3" class="mt-1 w-full border rounded px-2 py-1"><%= g.bio %></textarea>
+                <label class="block text-sm font-medium">Description
+                  <textarea name="description" rows="3" class="mt-1 w-full border rounded px-2 py-1"><%= g.description %></textarea>
+                </label>
+                <label class="block text-sm font-medium">Phone
+                  <input name="phone" value="<%= g.phone || '' %>" class="mt-1 w-full border rounded px-2 py-1"/>
+                </label>
+                <label class="block text-sm font-medium">Email
+                  <input name="email" value="<%= g.email || '' %>" class="mt-1 w-full border rounded px-2 py-1"/>
+                </label>
+                <label class="block text-sm font-medium">Address
+                  <textarea name="address" rows="2" class="mt-1 w-full border rounded px-2 py-1"><%= g.address || '' %></textarea>
+                </label>
+                <label class="block text-sm font-medium">Owner
+                  <input name="owner" value="<%= g.owner || '' %>" class="mt-1 w-full border rounded px-2 py-1"/>
+                </label>
+                <label class="block text-sm font-medium">Logo URL
+                  <input name="logoUrl" value="<%= g.logo_url || '' %>" class="mt-1 w-full border rounded px-2 py-1"/>
+                </label>
+                <label class="block text-sm font-medium">Logo File
+                  <input type="file" name="logoFile" accept="image/*" class="mt-1 w-full"/>
                 </label>
                 <div class="flex gap-2">
                   <button type="submit" class="save-btn bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Save</button>
@@ -52,7 +70,7 @@
             <span class="font-semibold flex-1">New Gallery</span>
           </button>
           <div class="gallery-form-wrapper max-h-0 opacity-0 overflow-hidden transition-all ease-in-out">
-            <form class="p-4 space-y-2 gallery-form" data-new="true">
+            <form class="p-4 space-y-2 gallery-form" data-new="true" enctype="multipart/form-data">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <label class="block text-sm font-medium">Slug
                 <input name="slug" value="<%= generatedSlug %>" class="mt-1 w-full border rounded px-2 py-1"/>
@@ -60,8 +78,26 @@
               <label class="block text-sm font-medium">Name
                 <input name="name" class="mt-1 w-full border rounded px-2 py-1"/>
               </label>
-              <label class="block text-sm font-medium">Bio
-                <textarea name="bio" rows="3" class="mt-1 w-full border rounded px-2 py-1"></textarea>
+              <label class="block text-sm font-medium">Description
+                <textarea name="description" rows="3" class="mt-1 w-full border rounded px-2 py-1"></textarea>
+              </label>
+              <label class="block text-sm font-medium">Phone
+                <input name="phone" class="mt-1 w-full border rounded px-2 py-1"/>
+              </label>
+              <label class="block text-sm font-medium">Email
+                <input name="email" class="mt-1 w-full border rounded px-2 py-1"/>
+              </label>
+              <label class="block text-sm font-medium">Address
+                <textarea name="address" rows="2" class="mt-1 w-full border rounded px-2 py-1"></textarea>
+              </label>
+              <label class="block text-sm font-medium">Owner
+                <input name="owner" class="mt-1 w-full border rounded px-2 py-1"/>
+              </label>
+              <label class="block text-sm font-medium">Logo URL
+                <input name="logoUrl" class="mt-1 w-full border rounded px-2 py-1"/>
+              </label>
+              <label class="block text-sm font-medium">Logo File
+                <input type="file" name="logoFile" accept="image/*" class="mt-1 w-full"/>
               </label>
               <div class="flex gap-2">
                 <button type="submit" class="save-btn bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Save</button>
@@ -103,23 +139,23 @@
         btn.disabled = true;
         const original = btn.textContent;
         btn.textContent = 'Saving...';
-        const dataObj = Object.fromEntries(new FormData(form).entries());
+        const formData = new FormData(form);
         const url = isNew ? '/dashboard/galleries' : '/dashboard/galleries/' + encodeURIComponent(slug);
         const method = isNew ? 'POST' : 'PUT';
         try {
           const res = await fetch(url, {
             method,
-            headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken },
-            body: JSON.stringify(dataObj)
+            headers: { 'CSRF-Token': csrfToken },
+            body: formData
           });
           if (!res.ok) throw new Error(await res.text() || res.statusText);
           btn.textContent = 'Saved!';
-          slug = dataObj.slug;
+          slug = formData.get('slug');
           form.dataset.slug = slug;
           if (isNew) {
             form.dataset.new = 'false';
           }
-          form.closest('li').querySelector('.gallery-toggle span').textContent = dataObj.name || dataObj.slug;
+          form.closest('li').querySelector('.gallery-toggle span').textContent = formData.get('name') || formData.get('slug');
           setTimeout(() => {
             btn.textContent = original;
             btn.disabled = false;


### PR DESCRIPTION
## Summary
- merge gallery settings with gallery management so phone, email, address, description, owner and logo are handled in /dashboard/galleries
- remove standalone settings page and redirect `/dashboard/settings`
- use galleries table to persist settings fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f9e430cac8320bd5c6c5f19ed1a55