### PR TITLE
Add account page and navigation link

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+
+function requireAuth(req, res, next) {
+  if (!req.user) {
+    return res.redirect('/login');
+  }
+  next();
+}
+
+router.get('/', requireAuth, (req, res) => {
+  res.render('account', { user: req.session.user });
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -91,12 +91,14 @@ migrate(() => initialize());
 const authRoutes = require('./routes/auth');
 const artistRoutes = require('./routes/dashboard/artist');
 const adminRoutes = require('./routes/dashboard/admin');
+const accountRoutes = require('./routes/account');
 const publicRoutes = require('./routes/public');
 
 // Mount routes
 app.use(authRoutes);
 app.use('/dashboard/artist', artistRoutes);
 app.use('/dashboard', adminRoutes);
+app.use('/account', accountRoutes);
 app.use(publicRoutes);
 
 // Render custom 404 page for any unmatched routes

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Account</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <%- include('partials/navbar'); %>
+  <main class="max-w-4xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-6 text-center">Account</h1>
+    <p class="mb-2 text-center">Username: <strong><%= user.username %></strong></p>
+    <p class="mb-4 text-center">Role: <strong><%= user.role %></strong></p>
+    <% if (user.role === 'gallery') { %>
+      <p class="mb-4 text-center">Public gallery URL: <a href="/<%= user.username %>" class="text-blue-600 underline">/<%= user.username %></a></p>
+    <% } else if (user.role === 'artist') { %>
+      <p class="mb-4 text-center">Manage your portfolio from the dashboard.</p>
+    <% } %>
+    <% const dashLink = user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard'; %>
+    <div class="flex justify-center gap-4">
+      <a href="<%= dashLink %>" class="border border-black px-4 py-2 rounded hover:bg-gray-100">Dashboard</a>
+      <a href="/account/password" class="border border-black px-4 py-2 rounded hover:bg-gray-100">Update Password</a>
+    </div>
+  </main>
+  <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+</body>
+</html>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -7,6 +7,9 @@
       <a href="/dashboard/artists" class="hover:underline">Artists</a>
     <% } %>
     <a href="/dashboard/artworks" class="hover:underline">Artworks</a>
+    <% if (user) { %>
+      <a href="/account" class="hover:underline">Account</a>
+    <% } %>
     <a href="/logout" class="hover:underline">Logout</a>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- Add `/account` route restricted to authenticated users.
- Create account view showing username, role, and relevant links.
- Update navbar to include an Account link when logged in.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa08d24dc8320b9bcc5251d6b2551