### PR TITLE
Add artist profile creation during signup

### DIFF
--- a/models/artistModel.js
+++ b/models/artistModel.js
@@ -11,4 +11,9 @@ function getArtist(gallerySlug, id, cb) {
   });
 }
 
-module.exports = { getArtist };
+function createArtist(id, name, gallerySlug, cb) {
+  const stmt = `INSERT INTO artists (id, gallery_slug, name) VALUES (?,?,?)`;
+  db.run(stmt, [id, gallerySlug, name], cb);
+}
+
+module.exports = { getArtist, createArtist };


### PR DESCRIPTION
## Summary
- add helper to create artists in the database
- link artist signup to artist creation with rollback on failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa433596083208f9ea4d6666f0aef