### PR TITLE
Auto-create gallery on signup

### DIFF
--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -31,4 +31,9 @@ function getGallery(slug, cb) {
   });
 }
 
-module.exports = { getGallery };
+function createGallery(slug, name, cb) {
+  const stmt = 'INSERT INTO galleries (slug, name) VALUES (?, ?)';
+  db.run(stmt, [slug, name], cb);
+}
+
+module.exports = { getGallery, createGallery };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { createUser, findUserByUsername } = require('../models/userModel');
 const { createArtist } = require('../models/artistModel');
+const { createGallery } = require('../models/galleryModel');
 const { db } = require('../models/db');
 const bcrypt = require('../utils/bcrypt');
 
@@ -27,6 +28,18 @@ function signupHandler(role) {
       }
       if (role === 'artist') {
         createArtist(id, display_name, '', err2 => {
+          if (err2) {
+            db.run('DELETE FROM users WHERE id = ?', [id], () => {
+              req.flash('error', 'Signup failed');
+              return res.redirect(`/signup/${role}`);
+            });
+            return;
+          }
+          req.session.user = { id, username, role };
+          return res.redirect(`/dashboard/${role}`);
+        });
+      } else if (role === 'gallery') {
+        createGallery(username, display_name, err2 => {
           if (err2) {
             db.run('DELETE FROM users WHERE id = ?', [id], () => {
               req.flash('error', 'Signup failed');

--- a/views/admin/galleries.ejs
+++ b/views/admin/galleries.ejs
@@ -73,7 +73,7 @@
             <form class="p-4 space-y-2 gallery-form" data-new="true" enctype="multipart/form-data">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <label class="block text-sm font-medium">Slug
-                <input name="slug" value="<%= generatedSlug %>" class="mt-1 w-full border rounded px-2 py-1"/>
+                <input name="slug" value="<%= user && user.role === 'gallery' ? user.username : generatedSlug %>" class="mt-1 w-full border rounded px-2 py-1"/>
               </label>
               <label class="block text-sm font-medium">Name
                 <input name="name" class="mt-1 w-full border rounded px-2 py-1"/>


### PR DESCRIPTION
## Summary
- add `createGallery` for inserting new galleries
- create gallery after `signup/gallery` using username as slug
- default new gallery slug to logged-in user's username in admin view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa4e492e08320b955842e3d66e62d