### PR TITLE
Validate slug-friendly usernames during signup

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -9,6 +9,7 @@ const bcrypt = require('../utils/bcrypt');
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
 const VALID_PROMO_CODES = ['taos'];
+const USERNAME_REGEX = /^[a-z0-9-]+$/;
 
 function signupHandler(role) {
   return (req, res) => {
@@ -19,6 +20,10 @@ function signupHandler(role) {
     }
     if (!VALID_PROMO_CODES.includes(passcode)) {
       req.flash('error', 'Invalid passcode');
+      return res.redirect(`/signup/${role}`);
+    }
+    if (!USERNAME_REGEX.test(username)) {
+      req.flash('error', 'Username may only contain lowercase letters, numbers, and hyphens');
       return res.redirect(`/signup/${role}`);
     }
     createUser(display_name, username, password, role, passcode, (err, id) => {

--- a/views/signup/artist.ejs
+++ b/views/signup/artist.ejs
@@ -27,6 +27,7 @@
         <div>
           <label class="block text-sm font-medium" for="username">Username</label>
           <input id="username" type="text" name="username" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+          <p class="text-xs text-gray-500 mt-1">Use lowercase letters, numbers, and hyphens only.</p>
         </div>
         <div>
           <label class="block text-sm font-medium" for="password">Password</label>

--- a/views/signup/gallery.ejs
+++ b/views/signup/gallery.ejs
@@ -27,6 +27,7 @@
         <div>
           <label class="block text-sm font-medium" for="username">Username</label>
           <input id="username" type="text" name="username" class="mt-1 w-full border border-gray-300 rounded px-3 py-2" required>
+          <p class="text-xs text-gray-500 mt-1">Use lowercase letters, numbers, and hyphens only.</p>
         </div>
         <div>
           <label class="block text-sm font-medium" for="password">Password</label>


### PR DESCRIPTION
## Summary
- enforce slug-friendly usernames on signup
- explain slug restrictions on the signup forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa6626aa0832080740352d2cd82d3