### PR TITLE
refactor: centralize auth middleware

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,20 @@
+function requireAuth(req, res, next) {
+  if (!req.user) {
+    return res.redirect('/login');
+  }
+  next();
+}
+
+function requireRole(...roles) {
+  return function(req, res, next) {
+    if (!req.user) {
+      return res.redirect('/login');
+    }
+    if (roles.length && !roles.includes(req.user.role)) {
+      return res.status(403).send('Forbidden');
+    }
+    next();
+  };
+}
+
+module.exports = { requireAuth, requireRole };

--- a/routes/account.js
+++ b/routes/account.js
@@ -1,12 +1,6 @@
 const express = require('express');
 const router = express.Router();
-
-function requireAuth(req, res, next) {
-  if (!req.user) {
-    return res.redirect('/login');
-  }
-  next();
-}
+const { requireAuth } = require('../middleware/auth');
 
 router.get('/', requireAuth, (req, res) => {
   res.render('account', { user: req.session.user });

--- a/routes/dashboard/admin.js
+++ b/routes/dashboard/admin.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const multer = require('multer');
 const randomAvatar = require('../../utils/avatar');
+const { requireRole } = require('../../middleware/auth');
 let Jimp;
 try {
   Jimp = require('jimp');
@@ -12,18 +13,6 @@ try {
 }
 
 const { db } = require('../../models/db');
-
-function requireRole(...roles) {
-  return function(req, res, next) {
-    if (!req.user) {
-      return res.redirect('/login');
-    }
-    if (!roles.includes(req.user.role)) {
-      return res.status(403).send('Forbidden');
-    }
-    next();
-  };
-}
 
 const uploadsDir = path.join(__dirname, '../../public', 'uploads');
 if (!fs.existsSync(uploadsDir)) {

--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const path = require('path');
 const fs = require('fs');
 const multer = require('multer');
+const { requireRole } = require('../../middleware/auth');
 let Jimp;
 try {
   Jimp = require('jimp');
@@ -68,13 +69,6 @@ async function processImages(file) {
     } catch {}
     throw err;
   }
-}
-
-function requireRole(role) {
-  return function(req, res, next) {
-    if (req.user && req.user.role === role) return next();
-    res.redirect('/login');
-  };
 }
 
 function slugify(str) {


### PR DESCRIPTION
## Summary
- centralize auth middleware for authentication and role-based access control
- reuse shared auth middleware in account, artist dashboard and admin dashboard routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa66403bc832088ac8435ba0f92b5