### PR TITLE
feat: load promo codes from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The server reads credentials and session configuration from environment variable
 - `ADMIN_PASSWORD` – password for the admin login (defaults to `password`)
 - `SESSION_SECRET` – secret used to sign session cookies (defaults to `gallerysecret`)
 - `USE_DEMO_AUTH` – set to `true` to automatically log into admin pages
+- `VALID_PROMO_CODES` – comma-separated list of passcodes required for signup (e.g. `code1,code2`). When unset, signups skip passcode verification.
 
 Set these variables before starting the server to override the defaults.
 

--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,8 @@ services:
         value: gallerysecret
       - key: USE_DEMO_AUTH
         value: true
+      - key: VALID_PROMO_CODES
+        value: taos
     disk:
       name: gallerydb
       mountPath: /opt/render/project/src

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -8,16 +8,26 @@ const bcrypt = require('../utils/bcrypt');
 
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
-const VALID_PROMO_CODES = ['taos'];
+const VALID_PROMO_CODES = process.env.VALID_PROMO_CODES
+  ? process.env.VALID_PROMO_CODES.split(',').map(c => c.trim()).filter(Boolean)
+  : null;
+if (!VALID_PROMO_CODES) {
+  console.warn('VALID_PROMO_CODES environment variable not set; signup passcodes will be ignored');
+}
 
 function signupHandler(role) {
   return (req, res) => {
     const { display_name, username, password, passcode } = req.body;
-    if (!display_name || !username || !password || !passcode) {
+    if (
+      !display_name ||
+      !username ||
+      !password ||
+      (VALID_PROMO_CODES && !passcode)
+    ) {
       req.flash('error', 'All fields are required');
       return res.redirect(`/signup/${role}`);
     }
-    if (!VALID_PROMO_CODES.includes(passcode)) {
+    if (VALID_PROMO_CODES && !VALID_PROMO_CODES.includes(passcode)) {
       req.flash('error', 'Invalid passcode');
       return res.redirect(`/signup/${role}`);
     }


### PR DESCRIPTION
## Summary
- load signup promo codes from the `VALID_PROMO_CODES` env variable
- document promo code configuration and Render deployment setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa66835ac8320ad9fa7afc585c529