### PR TITLE
Add CSRF mismatch logging for artist dashboard

### DIFF
--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -163,4 +163,14 @@ router.post('/artworks/:id/collection', requireRole('artist'), (req, res) => {
   });
 });
 
+// Handle CSRF token errors specifically for artist dashboard routes
+router.use((err, req, res, next) => {
+  if (err.code === 'EBADCSRFTOKEN') {
+    console.error('CSRF token mismatch on artist route', err);
+    req.flash('error', 'Invalid CSRF token. Please try again.');
+    return res.redirect('/dashboard/artist');
+  }
+  next(err);
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- handle CSRF token errors in artist dashboard routes by logging and flashing an error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa6a2dfc883209c0559e7272f4af0