### PR TITLE
feat: user-friendly CSRF error page

### DIFF
--- a/server.js
+++ b/server.js
@@ -109,7 +109,11 @@ app.use((req, res) => {
 // Handle CSRF token errors
 app.use((err, req, res, next) => {
   if (err.code === 'EBADCSRFTOKEN') {
-    return res.status(403).send('Invalid CSRF token');
+    const message = 'Your session has expired or the form was tampered with. Please refresh the page or log in again.';
+    if (req.flash) {
+      req.flash('error', message);
+    }
+    return res.status(403).render('csrf-error', { message });
   }
   console.error(err);
   res.status(500).send('Server error');

--- a/views/csrf-error.ejs
+++ b/views/csrf-error.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Security Error</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <main class="min-h-screen flex flex-col items-center justify-center text-center p-6">
+    <h1 class="text-xl font-bold mb-4">Security verification failed</h1>
+    <p class="text-base mb-4"><%= message %></p>
+    <p><a href="javascript:location.reload()" class="text-blue-600 underline">Refresh the page</a> or <a href="/login" class="text-blue-600 underline">log in again</a>.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show helpful CSRF error page instructing refresh or re-login
- handle invalid CSRF tokens with 403 status and optional flash message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa6a747908320989aa7a4bcb6a591