### PR TITLE
Add CSRF token to admin artwork forms and document templates

### DIFF
--- a/CSRF_TEMPLATES.md
+++ b/CSRF_TEMPLATES.md
@@ -1,0 +1,7 @@
+# CSRF Template Updates
+
+The following templates were updated to ensure CSRF protection:
+
+- `views/admin/artworks.ejs`: added hidden `_csrf` field to per-artwork edit forms.
+
+All other templates under `views/` already include CSRF fields in forms or set `CSRF-Token` headers for JavaScript `fetch` requests.

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -91,6 +91,7 @@
         <% artworks.forEach(function(art){ %>
           <li>
             <form class="art-form grid grid-cols-1 md:grid-cols-2 gap-4 file-or-url" data-id="<%= art.id %>" enctype="multipart/form-data">
+              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <input name="title" value="<%= art.title %>" class="border border-gray-300 rounded px-2 py-1 w-full">
               <div>
                 <select name="medium" class="border border-gray-300 rounded px-2 py-1 w-full medium-select" data-current="<%= art.medium %>">


### PR DESCRIPTION
## Summary
- ensure admin artwork edit forms carry CSRF hidden field
- document CSRF protection coverage in templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa6aada4c832091bcc968cc5aa528