### PR TITLE
feat: script-based image fade-in

### DIFF
--- a/public/js/fade-in.js
+++ b/public/js/fade-in.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const images = document.querySelectorAll('img[data-fade]');
+  images.forEach(img => {
+    const show = () => img.classList.remove('opacity-0');
+    if (img.complete) {
+      show();
+    } else {
+      img.addEventListener('load', show, { once: true });
+    }
+  });
+});

--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -25,7 +25,7 @@
         <% artist.artworks.forEach(function(art){ %>
           <li class="<%= art.isFeatured ? 'md:col-span-2' : '' %>">
             <a href="/<%= slug %>/artworks/<%= art.id %>" class="block">
-              <img src="<%= art.imageThumb %>" alt="<%= art.title %>" class="w-full mb-2 transition-opacity duration-700 opacity-0" loading="lazy" onload="this.classList.remove('opacity-0')">
+              <img src="<%= art.imageThumb %>" alt="<%= art.title %>" class="w-full mb-2 transition-opacity duration-700 opacity-0" loading="lazy" data-fade>
               <span class="font-semibold block"><%= art.title %></span>
 
               <% if (art.status) { %>
@@ -55,7 +55,7 @@
     </section>
 
     <section class="mt-16 flex flex-col items-center text-center">
-      <img src="<%= artist.bioImageUrl %>" alt="<%= artist.name %> portrait" class="w-36 h-36 rounded-full mb-4 transition-opacity duration-700 opacity-0" loading="lazy" onload="this.classList.remove('opacity-0')">
+      <img src="<%= artist.bioImageUrl %>" alt="<%= artist.name %> portrait" class="w-36 h-36 rounded-full mb-4 transition-opacity duration-700 opacity-0" loading="lazy" data-fade>
       <div class="space-y-4 max-w-prose">
         <% if (artist.fullBio) { %>
           <% artist.fullBio.split('\n\n').forEach(function(par){ %>
@@ -73,5 +73,6 @@
   <footer class="text-center py-6 border-t border-gray-200 mt-12">
     <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
   </footer>
+  <script src="/js/fade-in.js"></script>
 </body>
 </html>

--- a/views/artwork-detail.ejs
+++ b/views/artwork-detail.ejs
@@ -35,7 +35,7 @@
     </header>
 
     <div class="mb-8">
-      <img src="<%= artwork.imageStandard %>" alt="<%= artwork.title %>" class="mx-auto max-w-full transition-opacity duration-700 opacity-0" loading="lazy" onload="this.classList.remove('opacity-0')">
+      <img src="<%= artwork.imageStandard %>" alt="<%= artwork.title %>" class="mx-auto max-w-full transition-opacity duration-700 opacity-0" loading="lazy" data-fade>
     </div>
 
     <ul class="max-w-md mx-auto divide-y divide-gray-200 text-center text-base">
@@ -54,5 +54,6 @@
   <footer class="text-center py-6 border-t border-gray-200 mt-12">
     <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
   </footer>
+  <script src="/js/fade-in.js"></script>
 </body>
 </html>

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -30,7 +30,7 @@
           <li>
             <a href="/<%= slug %>/artworks/<%= art.id %>" class="block text-center">
               <img src="<%= art.imageStandard %>" alt="<%= art.title %>" loading="lazy"
-                   class="block w-full h-auto transition-opacity duration-700 opacity-0" onload="this.classList.remove('opacity-0')">
+                   class="block w-full h-auto transition-opacity duration-700 opacity-0" data-fade>
               <div class="mt-2 space-y-1">
                 <span class="font-semibold block"><%= art.title %></span>
                 <span class="text-sm"><%= art.artistName %></span>
@@ -64,5 +64,6 @@
   <footer class="text-center py-6 border-t border-gray-200 mt-12">
     <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
   </footer>
+  <script src="/js/fade-in.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize image fade-in behaviour with a tiny JS helper
- drop inline `onload` handlers from gallery templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c4377ddc832095ffd663b1d8c117