### PR TITLE
Show flash messages on dashboards

### DIFF
--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -9,6 +9,12 @@
   <%- include('../partials/navbar'); %>
   <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-6 text-center"><%= user.role.charAt(0).toUpperCase() + user.role.slice(1) %> Dashboard</h1>
+    <% if (flash.error && flash.error.length) { %>
+      <p class="text-red-600 mb-4"><%= flash.error[0] %></p>
+    <% } %>
+    <% if (flash.success && flash.success.length) { %>
+      <p class="text-green-600 mb-4"><%= flash.success[0] %></p>
+    <% } %>
     <section class="mb-8">
       <h2 class="text-xl font-semibold mb-4">Profile</h2>
       <form method="POST" action="/dashboard/artist/profile" enctype="multipart/form-data" class="space-y-2">

--- a/views/dashboard/gallery.ejs
+++ b/views/dashboard/gallery.ejs
@@ -9,6 +9,12 @@
   <%- include('../partials/navbar'); %>
   <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-6 text-center"><%= user.role.charAt(0).toUpperCase() + user.role.slice(1) %> Dashboard</h1>
+    <% if (flash.error && flash.error.length) { %>
+      <p class="text-red-600 mb-4"><%= flash.error[0] %></p>
+    <% } %>
+    <% if (flash.success && flash.success.length) { %>
+      <p class="text-green-600 mb-4"><%= flash.success[0] %></p>
+    <% } %>
     <% const dashBase = '/dashboard'; %>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
       <a href="<%= dashBase %>/galleries" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">My Gallery</a>


### PR DESCRIPTION
## Summary
- show flash.error and flash.success messages on artist dashboard
- show flash.error and flash.success messages on gallery dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c44166cc83208029346371595f1d