### PR TITLE
refactor: add shared head and footer partials

### DIFF
--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,15 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Page Not Found</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Page Not Found' }) %>
   <main class="min-h-screen flex flex-col items-center justify-center text-center p-6">
     <h1 class="text-xl font-bold mb-4">404 - Page Not Found</h1>
     <p class="text-base mb-4">The page you are looking for doesn't exist.</p>
     <p><a href="/" class="text-blue-600 underline">Return to home</a></p>
   </main>
-</body>
-</html>
+<%- include('partials/footer') %>

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Account</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Account' }) %>
   <%- include('partials/navbar'); %>
   <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-6 text-center">Account</h1>
@@ -22,8 +15,4 @@
       <a href="/account/password" class="border border-black px-4 py-2 rounded hover:bg-gray-100">Update Password</a>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Manage Artists</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-  <meta name="csrf-token" content="<%= csrfToken %>">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', {
+  title: 'Manage Artists',
+  headExtras: `<meta name="csrf-token" content="${csrfToken}">`
+}) %>
   <%- include('../partials/navbar'); %>
   <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
   <main class="max-w-3xl mx-auto p-6">
@@ -97,9 +92,6 @@
       <p class="mt-6"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
   <script>
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     function toggleWrapper(wrapper) {
@@ -186,5 +178,4 @@
       btn.click();
     });
   </script>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Manage Artworks</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-  <meta name="csrf-token" content="<%= csrfToken %>">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', {
+  title: 'Manage Artworks',
+  headExtras: `<meta name="csrf-token" content="${csrfToken}">`
+}) %>
     <%- include('../partials/navbar'); %>
     <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
     <main class="max-w-3xl mx-auto p-6">
@@ -138,9 +133,6 @@
         <p class="mt-6"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
   <script>
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
@@ -269,5 +261,4 @@
       });
     });
   </script>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Dashboard</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Dashboard' }) %>
       <%- include('../partials/navbar'); %>
     <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-8 text-center"><%= user && user.role ? (user.role.charAt(0).toUpperCase() + user.role.slice(1)) : 'Admin' %> Dashboard</h1>
@@ -27,8 +20,4 @@
       <a href="/logout" class="text-sm text-gray-600 underline">Logout</a>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/admin/galleries.ejs
+++ b/views/admin/galleries.ejs
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Manage Galleries</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-  <meta name="csrf-token" content="<%= csrfToken %>">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', {
+  title: 'Manage Galleries',
+  headExtras: `<meta name="csrf-token" content="${csrfToken}">`
+}) %>
   <%- include('../partials/navbar'); %>
   <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
   <main class="max-w-3xl mx-auto p-6">
@@ -110,9 +105,6 @@
       <p class="mt-6"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
   <script>
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     function toggleWrapper(wrapper) {
@@ -197,5 +189,4 @@
       btn.click();
     });
   </script>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/admin/settings.ejs
+++ b/views/admin/settings.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Gallery Settings</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Gallery Settings' }) %>
     <%- include('../partials/navbar'); %>
     <% const dashboardUrl = user ? (user.role === 'artist' ? '/dashboard/artist' : user.role === 'gallery' ? '/dashboard/gallery' : '/dashboard') : '/dashboard'; %>
     <main class="max-w-xl mx-auto p-6">
@@ -60,8 +53,4 @@
         <p class="mt-6 text-center"><a href="<%= dashboardUrl %>" class="text-blue-600 underline">Back to dashboard</a></p>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -1,12 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Upload Artwork</title>
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', {
+  title: 'Upload Artwork',
+  htmlLang: 'en',
+  headExtras: '<meta charset="UTF-8">'
+}) %>
     <%- include('../partials/navbar'); %>
     <main class="max-w-lg mx-auto p-6">
     <div class="border border-gray-200 p-6 rounded shadow">
@@ -92,10 +88,6 @@
       </ul>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-
   <script>
     const imageInput = document.getElementById('image');
   const previewImg = document.getElementById('preview');
@@ -143,5 +135,4 @@
     submitLabel.textContent = 'Saving...';
   });
   </script>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title><%= artist.name %> - <%= gallery.name %></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: artist.name + ' - ' + gallery.name }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
     <div class="flex gap-4 mt-2 md:mt-0">
@@ -70,8 +63,4 @@
     </div>
   </main>
 
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/artwork-detail.ejs
+++ b/views/artwork-detail.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title><%= artwork.title %> - <%= gallery.name %></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: artwork.title + ' - ' + gallery.name }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
     <div class="flex gap-4 mt-2 md:mt-0">
@@ -51,8 +44,4 @@
     </div>
   </main>
 
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/csrf-error.ejs
+++ b/views/csrf-error.ejs
@@ -1,15 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Security Error</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Security Error' }) %>
   <main class="min-h-screen flex flex-col items-center justify-center text-center p-6">
     <h1 class="text-xl font-bold mb-4">Security verification failed</h1>
     <p class="text-base mb-4"><%= message %></p>
     <p><a href="javascript:location.reload()" class="text-blue-600 underline">Refresh the page</a> or <a href="/login" class="text-blue-600 underline">log in again</a>.</p>
   </main>
-</body>
-</html>
+<%- include('partials/footer') %>

--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Artist Dashboard</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Artist Dashboard' }) %>
   <%- include('../partials/navbar'); %>
   <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-6 text-center"><%= user.role.charAt(0).toUpperCase() + user.role.slice(1) %> Dashboard</h1>
@@ -74,8 +67,4 @@
       <% }) %>
     </section>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -1,12 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Artwork Management</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-  <meta name="csrf-token" content="<%= csrfToken %>">
-</head>
-<body class="font-sans bg-gray-50 text-black">
+<%- include('partials/head', {
+  title: 'Artwork Management',
+  bodyClass: 'font-sans bg-gray-50 text-black',
+  headExtras: `<meta name="csrf-token" content="${csrfToken}">`
+}) %>
   <%- include('../partials/navbar'); %>
   <main class="max-w-4xl mx-auto p-4">
     <button id="new-artwork" class="mb-4 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">New Artwork</button>
@@ -171,5 +167,4 @@
       btn.click();
     });
   </script>
-</body>
-</html>
+<%- include('partials/footer') %>

--- a/views/dashboard/gallery.ejs
+++ b/views/dashboard/gallery.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Gallery Dashboard</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Gallery Dashboard' }) %>
   <%- include('../partials/navbar'); %>
   <main class="max-w-4xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-6 text-center"><%= user.role.charAt(0).toUpperCase() + user.role.slice(1) %> Dashboard</h1>
@@ -17,8 +10,4 @@
       <a href="<%= dashBase %>/settings" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">Gallery Settings</a>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>FAQ - FineArtSuite</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'FAQ - FineArtSuite' }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
     <div class="flex gap-4 mt-2 md:mt-0">
@@ -40,8 +33,4 @@
       </p>
     </section>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -1,15 +1,11 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title><%= gallery.name %> - Gallery</title>
-  <meta name="description" content="<%= gallery.bio %>">
-  <meta property="og:title" content="<%= gallery.name %>">
-  <meta property="og:description" content="<%= gallery.bio %>">
-  <meta property="og:type" content="website">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', {
+  title: gallery.name + ' - Gallery',
+  headExtras: `
+  <meta name="description" content="${gallery.bio}">
+  <meta property="og:title" content="${gallery.name}">
+  <meta property="og:description" content="${gallery.bio}">
+  <meta property="og:type" content="website">`
+}) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
     <div class="flex gap-4 mt-2 md:mt-0">
@@ -61,8 +57,4 @@
     </div>
   </main>
 
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>FineArt Gallery SaaS</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'FineArt Gallery SaaS' }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
       <div class="flex gap-4 mt-2 md:mt-0">
@@ -53,8 +46,4 @@
     </div>
   </section>
 
-  <footer class="text-center py-6 border-t border-gray-200">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer') %>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Login</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Login' }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
       <div class="flex gap-4 mt-2 md:mt-0">
@@ -39,8 +32,4 @@
         <p class="mt-4 text-center"><a href="/" class="text-blue-600 underline">Back home</a></p>
       </div>
     </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,0 +1,5 @@
+  <footer class="text-center py-6 border-t border-gray-200 <%= footerClass || '' %>">
+    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+  </footer>
+</body>
+</html>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html<% if (htmlLang) { %> lang="<%= htmlLang %>"<% } %>>
+<head>
+  <title><%= title %></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+  <%- headExtras || '' %>
+</head>
+<body class="<%= bodyClass || 'font-sans bg-white text-black' %>">

--- a/views/signup/artist.ejs
+++ b/views/signup/artist.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Artist Signup</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Artist Signup' }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
     <div class="flex gap-4 mt-2 md:mt-0">
@@ -42,8 +35,4 @@
       </form>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/signup/gallery.ejs
+++ b/views/signup/gallery.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Gallery Signup</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Gallery Signup' }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
     <div class="flex gap-4 mt-2 md:mt-0">
@@ -42,8 +35,4 @@
       </form>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>

--- a/views/signup/index.ejs
+++ b/views/signup/index.ejs
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Sign Up</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/main.css">
-</head>
-<body class="font-sans bg-white text-black">
+<%- include('partials/head', { title: 'Sign Up' }) %>
   <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
     <a href="/" class="text-2xl font-bold">FineArtSuite</a>
     <div class="flex gap-4 mt-2 md:mt-0">
@@ -20,8 +13,4 @@
       <a href="/signup/gallery" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded text-base">Sign up as Gallery</a>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
-</body>
-</html>
+<%- include('partials/footer', { footerClass: 'mt-12' }) %>


### PR DESCRIPTION
## Summary
- add reusable `head` and `footer` partials for EJS templates
- update all views to use the shared partials

## Testing
- `npm test` *(fails: Expected values to be strictly equal: 500 !== 200)*

------
https://chatgpt.com/codex/tasks/task_e_6890c450a6ac8320a7d854dd93fbb5d8