### PR TITLE
Display gallery names on homepage

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -7,7 +7,7 @@ const { getArtwork } = require('../models/artworkModel');
 
 // Home route displaying available galleries
 router.get('/', (req, res) => {
-  db.all('SELECT slug FROM galleries', (err, rows) => {
+  db.all('SELECT slug, name FROM galleries', (err, rows) => {
     const galleries = err ? [] : rows;
     res.render('home', { galleries });
   });

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -105,6 +105,13 @@ test('homepage responds with welcome text', async () => {
   assert.match(body, /FineArtSuite/);
 });
 
+test('homepage lists gallery names instead of slugs', async () => {
+  const port = server.address().port;
+  const { body } = await httpGet(`http://localhost:${port}/`);
+  assert.ok(body.includes('>Demo Gallery</a>'));
+  assert.doesNotMatch(body, />demo-gallery<\/a>/);
+});
+
 test('gallery page responds with gallery name', async () => {
   const port = server.address().port;
   const { statusCode, body } = await httpGet(`http://localhost:${port}/demo-gallery`);

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -31,7 +31,7 @@
     <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-center">
       <% galleries.forEach(g => { %>
         <li>
-          <a href="/<%= g.slug %>" class="block border border-gray-200 p-4 hover:bg-gray-50"><%= g.slug %></a>
+          <a href="/<%= g.slug %>" class="block border border-gray-200 p-4 hover:bg-gray-50"><%= g.name %></a>
         </li>
       <% }) %>
     </ul>


### PR DESCRIPTION
## Summary
- Show gallery names on the homepage instead of their slugs
- Fetch name field for galleries in the public route
- Add test to ensure homepage lists gallery names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890cbe3da388320bd56a683a0d75ab2