### PR TITLE
Add artwork details and seed additional pieces

### DIFF
--- a/migrations/002_add_artwork_details.sql
+++ b/migrations/002_add_artwork_details.sql
@@ -1,0 +1,4 @@
+-- Add new artwork detail columns
+ALTER TABLE artworks ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE artworks ADD COLUMN IF NOT EXISTS framed INTEGER DEFAULT 0;
+ALTER TABLE artworks ADD COLUMN IF NOT EXISTS ready_to_hang INTEGER DEFAULT 0;

--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -19,7 +19,10 @@ function getArtwork(gallerySlug, id, cb) {
       hide_collected: row.hide_collected,
       featured: row.featured,
       isVisible: row.isVisible,
-      isFeatured: row.isFeatured
+      isFeatured: row.isFeatured,
+      description: row.description,
+      framed: row.framed,
+      readyToHang: row.ready_to_hang
     };
     cb(null, { artwork, artistId: row.artistId });
   });
@@ -33,12 +36,12 @@ function updateArtworkCollection(id, collectionId, cb) {
   db.run('UPDATE artworks SET collection_id = ? WHERE id = ?', [collectionId, id], cb);
 }
 
-function createArtwork(artistId, title, medium, dimensions, price, images, cb) {
+function createArtwork(artistId, title, medium, dimensions, price, description, framed, readyToHang, images, cb) {
   db.get('SELECT gallery_slug FROM artists WHERE id = ?', [artistId], (err, row) => {
     if (err || !row) return cb(err || new Error('Artist not found'));
     const id = 'art_' + Date.now();
-    const stmt = `INSERT INTO artworks (id, artist_id, gallery_slug, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured)
-                  VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`;
+    const stmt = `INSERT INTO artworks (id, artist_id, gallery_slug, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured, description, framed, ready_to_hang)
+                  VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
     const params = [
       id,
       artistId,
@@ -52,7 +55,10 @@ function createArtwork(artistId, title, medium, dimensions, price, images, cb) {
       images.imageThumb,
       'available',
       1,
-      0
+      0,
+      description || '',
+      framed ? 1 : 0,
+      readyToHang ? 1 : 0
     ];
     db.run(stmt, params, err2 => cb(err2, id));
   });

--- a/models/db.js
+++ b/models/db.js
@@ -66,7 +66,10 @@ function initialize() {
       hide_collected INTEGER DEFAULT 0,
       featured INTEGER DEFAULT 0,
       isVisible INTEGER DEFAULT 1,
-      isFeatured INTEGER DEFAULT 0
+      isFeatured INTEGER DEFAULT 0,
+      description TEXT,
+      framed INTEGER DEFAULT 0,
+      ready_to_hang INTEGER DEFAULT 0
     )`);
 
     db.get('SELECT COUNT(*) as count FROM galleries', (err, row) => {
@@ -153,7 +156,7 @@ function seed(done) {
   userStmt.run('Demo User', 'demouser', demoHash, 'artist', 'taos');
   userStmt.finalize();
 
-  const artworkStmt = db.prepare('INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, hide_collected, featured, isVisible, isFeatured) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
+  const artworkStmt = db.prepare('INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, hide_collected, featured, isVisible, isFeatured, description, framed, ready_to_hang) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
 
   function randomImage() {
     const id = Math.floor(Math.random() * 90) + 10; // 10-99
@@ -174,16 +177,37 @@ function seed(done) {
   }
 
   const mediums = ['Oil', 'Acrylic', 'Digital', 'Watercolor'];
+  const adjectives = ['Crimson', 'Luminous', 'Silent', 'Mystic', 'Azure', 'Golden', 'Ethereal', 'Verdant', 'Shadowed', 'Radiant'];
+  const nouns = ['Reverie', 'Horizon', 'Echo', 'Forest', 'Dream', 'Symphony', 'Canvas', 'Whisper', 'Rhythm', 'Voyage'];
+  const descriptions = [
+    'An exploration of light and shadow.',
+    'A vibrant study in color.',
+    'Inspired by urban landscapes.',
+    'An abstract representation of emotion.',
+    'A minimalist piece evoking serenity.',
+    'Textures from nature combined with bold hues.',
+    'A digital collage capturing movement.',
+    'A contemplative work examining space.'
+  ];
+
+  function generateTitle(artist, index) {
+    const a = adjectives[(index + artist.id.length) % adjectives.length];
+    const n = nouns[(index * 3 + artist.id.length) % nouns.length];
+    return `${a} ${n}`;
+  }
 
   artists.forEach(artist => {
-    for (let i = 1; i <= 5; i++) {
+    for (let i = 0; i < 8; i++) {
       const img = randomImage();
-      const artId = `${artist.id}-art${i}`;
-      const title = `Artwork ${i}`;
-      const medium = mediums[(i - 1) % mediums.length];
-      const status = i === 1 ? 'collected' : 'available';
-      const isFeatured = i === 1 ? 1 : 0;
-      artworkStmt.run(artId, artist.id, title, medium, '24x36', randomPrice(), img, img, img, status, 0, 0, 1, isFeatured);
+      const artId = `${artist.id}-art${i + 1}`;
+      const title = generateTitle(artist, i);
+      const medium = mediums[i % mediums.length];
+      const status = i === 0 ? 'collected' : 'available';
+      const isFeatured = i === 0 ? 1 : 0;
+      const description = descriptions[(i + artist.id.length) % descriptions.length];
+      const framed = i % 2 === 0 ? 1 : 0;
+      const ready = (i + 1) % 2 === 0 ? 1 : 0;
+      artworkStmt.run(artId, artist.id, title, medium, '24x36', randomPrice(), img, img, img, status, 0, 0, 1, isFeatured, description, framed, ready);
     }
   });
 

--- a/routes/dashboard/admin.js
+++ b/routes/dashboard/admin.js
@@ -425,7 +425,7 @@ router.post('/artworks', requireRole('admin', 'gallery'), (req, res) => {
       return res.redirect('/dashboard/artworks');
     }
     try {
-      let { id, gallery_slug, artist_id, title, medium, custom_medium, dimensions, price, imageUrl, status, isVisible, isFeatured } = req.body;
+      let { id, gallery_slug, artist_id, title, medium, custom_medium, dimensions, price, description, framed, readyToHang, imageUrl, status, isVisible, isFeatured } = req.body;
       if (req.user.role === 'gallery') {
         gallery_slug = req.user.username;
       }
@@ -486,8 +486,8 @@ router.post('/artworks', requireRole('admin', 'gallery'), (req, res) => {
         images.imageStandard = imageUrl;
         images.imageThumb = imageUrl;
       }
-      const stmt = `INSERT INTO artworks (id, gallery_slug, artist_id, title, medium, custom_medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
-      const params = [id, gallery_slug, artist_id, title, medium, custom_medium || '', dimensions, priceValue, images.imageFull, images.imageStandard, images.imageThumb, status || '', isVisible ? 1 : 0, isFeatured ? 1 : 0];
+      const stmt = `INSERT INTO artworks (id, gallery_slug, artist_id, title, medium, custom_medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured, description, framed, ready_to_hang) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
+      const params = [id, gallery_slug, artist_id, title, medium, custom_medium || '', dimensions, priceValue, images.imageFull, images.imageStandard, images.imageThumb, status || '', isVisible ? 1 : 0, isFeatured ? 1 : 0, description || '', framed ? 1 : 0, readyToHang ? 1 : 0];
       db.run(stmt, params, runErr => {
         if (runErr) {
           console.error(runErr);
@@ -520,7 +520,7 @@ router.put('/artworks/:id', requireRole('admin', 'gallery'), async (req, res) =>
           return res.status(403).send('Forbidden');
         }
       }
-      const { title, medium, custom_medium, dimensions, price, imageUrl, status, isVisible, isFeatured } = req.body;
+      const { title, medium, custom_medium, dimensions, price, description, framed, readyToHang, imageUrl, status, isVisible, isFeatured } = req.body;
       const finalMedium = medium === 'other' ? custom_medium : medium;
       let finalPrice = null;
       if (status !== 'collected') {
@@ -535,8 +535,8 @@ router.put('/artworks/:id', requireRole('admin', 'gallery'), async (req, res) =>
           finalPrice = '';
         }
       }
-      let stmt = `UPDATE artworks SET title=?, medium=?, dimensions=?, price=?, status=?, isVisible=?, isFeatured=?`;
-      const params = [title, finalMedium, dimensions, finalPrice, status || '', isVisible ? 1 : 0, isFeatured ? 1 : 0];
+      let stmt = `UPDATE artworks SET title=?, medium=?, dimensions=?, price=?, status=?, isVisible=?, isFeatured=?, description=?, framed=?, ready_to_hang=?`;
+      const params = [title, finalMedium, dimensions, finalPrice, status || '', isVisible ? 1 : 0, isFeatured ? 1 : 0, description || '', framed ? 1 : 0, readyToHang ? 1 : 0];
       if (req.file || imageUrl) {
         if (req.file && imageUrl) {
           return res.status(400).send('Choose either an upload or a URL');
@@ -615,7 +615,7 @@ router.post('/upload', requireRole('admin', 'gallery'), (req, res) => {
       return res.status(400).redirect('/dashboard/upload');
     }
 
-    let { id, gallery_slug, title, medium, custom_medium, dimensions, price, status, isVisible, isFeatured } = req.body;
+    let { id, gallery_slug, title, medium, custom_medium, dimensions, price, description, framed, readyToHang, status, isVisible, isFeatured } = req.body;
     if (!gallery_slug || !title || !medium || !dimensions || !status) {
       req.flash('error', 'All fields are required');
       return res.status(400).redirect('/dashboard/upload');
@@ -643,8 +643,8 @@ router.post('/upload', requireRole('admin', 'gallery'), (req, res) => {
         const finalMedium = medium === 'other' ? custom_medium : medium;
         const finalPrice = status === 'collected' ? null : price;
         const images = await processImages(req.file);
-        const stmt = `INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`;
-        db.run(stmt, [artworkId, artist.id, title, finalMedium, dimensions, finalPrice, images.imageFull, images.imageStandard, images.imageThumb, status, isVisible ? 1 : 0, isFeatured ? 1 : 0], runErr => {
+        const stmt = `INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured, description, framed, ready_to_hang) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
+        db.run(stmt, [artworkId, artist.id, title, finalMedium, dimensions, finalPrice, images.imageFull, images.imageStandard, images.imageThumb, status, isVisible ? 1 : 0, isFeatured ? 1 : 0, description || '', framed ? 1 : 0, readyToHang ? 1 : 0], runErr => {
           if (runErr) {
             console.error(runErr);
             req.flash('error', 'Database error');

--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -158,7 +158,7 @@ router.post('/artworks', requireRole('artist'), (req, res) => {
       req.flash('error', err.message);
       return res.redirect('/dashboard/artist');
     }
-    const { title, medium, dimensions, price, imageUrl, action = 'upload' } = req.body;
+    const { title, medium, dimensions, price, description, framed, readyToHang, imageUrl, action = 'upload' } = req.body;
     if (!title || !medium || !dimensions) {
       req.flash('error', 'All fields are required');
       return res.redirect('/dashboard/artist');
@@ -182,7 +182,7 @@ router.post('/artworks', requireRole('artist'), (req, res) => {
       } else {
         images = { imageFull: '', imageStandard: '', imageThumb: '' };
       }
-      createArtwork(req.session.user.id, title, medium, dimensions, price, images, createErr => {
+      createArtwork(req.session.user.id, title, medium, dimensions, price, description, framed === 'on', readyToHang === 'on', images, createErr => {
         if (createErr) {
           console.error(createErr);
           req.flash('error', 'Could not create artwork');

--- a/views/admin/artworks.ejs
+++ b/views/admin/artworks.ejs
@@ -55,6 +55,18 @@
           <label class="block text-sm font-medium" for="price">Price</label>
           <input id="price" type="number" step="0.01" name="price" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
         </div>
+        <div class="md:col-span-2">
+          <label class="block text-sm font-medium" for="description">Description</label>
+          <textarea id="description" name="description" class="mt-1 w-full border border-gray-300 rounded px-2 py-1"></textarea>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="framed" name="framed" value="1" class="mr-2">
+          <label for="framed" class="text-sm">Framed</label>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="readyToHang" name="readyToHang" value="1" class="mr-2">
+          <label for="readyToHang" class="text-sm">Ready to Hang</label>
+        </div>
         <div>
           <label class="block text-sm font-medium" for="imageFile">Upload Image</label>
           <input id="imageFile" type="file" name="imageFile" accept="image/*" class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
@@ -101,14 +113,25 @@
                 <input name="custom_medium" class="border border-gray-300 rounded px-2 py-1 w-full mt-1 hidden" placeholder="Specify medium">
               </div>
               <input name="dimensions" value="<%= art.dimensions %>" class="border border-gray-300 rounded px-2 py-1 w-full">
-              <div class="price-wrapper">
-                <input type="number" step="0.01" name="price" value="<%= art.price %>" class="border border-gray-300 rounded px-2 py-1 w-full">
-              </div>
-              <input type="file" name="imageFile" accept="image/*" class="border border-gray-300 rounded px-2 py-1 w-full">
-              <details class="text-sm text-gray-600">
-                <summary class="cursor-pointer">Paste URL instead</summary>
-                <input name="imageUrl" class="border border-gray-300 rounded px-2 py-1 w-full">
-              </details>
+                <div class="price-wrapper">
+                  <input type="number" step="0.01" name="price" value="<%= art.price %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+                </div>
+                <label class="block text-sm font-medium col-span-full">Description
+                  <textarea name="description" class="mt-1 w-full border border-gray-300 rounded px-2 py-1"><%= art.description || '' %></textarea>
+                </label>
+                <div class="flex items-center">
+                  <input type="checkbox" name="framed" value="1" class="mr-2" <%= art.framed ? 'checked' : '' %>>
+                  <span class="text-sm">Framed</span>
+                </div>
+                <div class="flex items-center">
+                  <input type="checkbox" name="readyToHang" value="1" class="mr-2" <%= art.ready_to_hang ? 'checked' : '' %>>
+                  <span class="text-sm">Ready to Hang</span>
+                </div>
+                <input type="file" name="imageFile" accept="image/*" class="border border-gray-300 rounded px-2 py-1 w-full">
+                <details class="text-sm text-gray-600">
+                  <summary class="cursor-pointer">Paste URL instead</summary>
+                  <input name="imageUrl" class="border border-gray-300 rounded px-2 py-1 w-full">
+                </details>
               <select name="status" class="border border-gray-300 rounded px-2 py-1 w-full status-select" data-current="<%= art.status %>">
                 <option value="available">Available</option>
                 <option value="inquire">Inquire</option>

--- a/views/admin/upload.ejs
+++ b/views/admin/upload.ejs
@@ -52,6 +52,18 @@
           <label class="block text-sm font-medium" for="price">Price</label>
           <input type="number" id="price" name="price" step="0.01" required class="mt-1 w-full border border-gray-300 rounded px-2 py-1">
         </div>
+        <div class="md:col-span-2">
+          <label class="block text-sm font-medium" for="description">Description</label>
+          <textarea id="description" name="description" class="mt-1 w-full border border-gray-300 rounded px-2 py-1"></textarea>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="framed" name="framed" class="mr-2">
+          <label for="framed" class="text-sm">Framed</label>
+        </div>
+        <div class="flex items-center">
+          <input type="checkbox" id="readyToHang" name="readyToHang" class="mr-2">
+          <label for="readyToHang" class="text-sm">Ready to Hang</label>
+        </div>
         <div>
           <label class="block text-sm font-medium" for="image">Image</label>
           <input type="file" id="image" name="image" accept="image/*" required class="mt-1 w-full">

--- a/views/artwork-detail.ejs
+++ b/views/artwork-detail.ejs
@@ -55,8 +55,8 @@
           <li><span class="font-semibold">Medium:</span> <%= artwork.medium %></li>
           <li><span class="font-semibold">Size:</span> <%= artwork.dimensions %></li>
           <% if (artwork.rarity) { %><li><span class="font-semibold">Rarity:</span> <%= artwork.rarity %></li><% } %>
-          <% if (artwork.framing) { %><li><span class="font-semibold">Framing:</span> <%= artwork.framing %></li><% } %>
-          <% if (artwork.readyToHang) { %><li><span class="font-semibold">Ready to Hang:</span> <%= artwork.readyToHang %></li><% } %>
+          <li><span class="font-semibold">Framed:</span> <%= artwork.framed ? 'Yes' : 'No' %></li>
+          <li><span class="font-semibold">Ready to Hang:</span> <%= artwork.readyToHang ? 'Yes' : 'No' %></li>
         </ul>
       </div>
     </section>

--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -56,6 +56,9 @@
         <input type="text" name="medium" placeholder="Medium" required class="border border-gray-300 rounded px-2 py-1 w-full">
         <input type="text" name="dimensions" placeholder="Dimensions" required class="border border-gray-300 rounded px-2 py-1 w-full">
         <input type="text" name="price" placeholder="Price" class="border border-gray-300 rounded px-2 py-1 w-full">
+        <textarea name="description" placeholder="Description" class="border border-gray-300 rounded px-2 py-1 w-full"></textarea>
+        <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="framed" class="border-gray-300">Framed</label>
+        <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="readyToHang" class="border-gray-300">Ready to Hang</label>
         <input type="file" name="imageFile" accept="image/*" class="border border-gray-300 rounded px-2 py-1 w-full">
         <input type="url" name="imageUrl" placeholder="Image URL" class="border border-gray-300 rounded px-2 py-1 w-full">
         <p class="text-xs text-gray-500">Provide an image file or a URL</p>

--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -27,6 +27,17 @@
                 <label class="block text-sm font-medium">Price
                   <input type="text" name="price" value="<%= art.price %>" class="mt-1 w-full border rounded px-2 py-1"/>
                 </label>
+                <label class="block text-sm font-medium">Description
+                  <textarea name="description" class="mt-1 w-full border rounded px-2 py-1"><%= art.description || '' %></textarea>
+                </label>
+                <label class="flex items-center gap-2 text-sm">
+                  <input type="checkbox" name="framed" value="1" <%= art.framed ? 'checked' : '' %>>
+                  Framed
+                </label>
+                <label class="flex items-center gap-2 text-sm">
+                  <input type="checkbox" name="readyToHang" value="1" <%= art.ready_to_hang ? 'checked' : '' %>>
+                  Ready to Hang
+                </label>
               <label class="block text-sm font-medium">Status
                 <select name="status" class="mt-1 w-full border rounded px-2 py-1">
                   <option value="available" <%= art.status === 'available' ? 'selected' : '' %>>Available</option>
@@ -78,6 +89,17 @@
           </label>
           <label class="block text-sm font-medium">Price
             <input type="text" name="price" class="mt-1 w-full border rounded px-2 py-1"/>
+          </label>
+          <label class="block text-sm font-medium">Description
+            <textarea name="description" class="mt-1 w-full border rounded px-2 py-1"></textarea>
+          </label>
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="framed" value="1">
+            Framed
+          </label>
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="readyToHang" value="1">
+            Ready to Hang
           </label>
           <label class="block text-sm font-medium">Status
             <select name="status" class="mt-1 w-full border rounded px-2 py-1">


### PR DESCRIPTION
## Summary
- add `description`, `framed`, and `ready_to_hang` fields for artworks with migration and model updates
- update artist/admin upload workflows and artwork views to capture and display new details
- seed creative descriptions and three extra artworks per artist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890e1f0413883208b27dc7f649b3da4