### PR TITLE
Add Western Gallery seed data and contact info on pages

### DIFF
--- a/models/db.js
+++ b/models/db.js
@@ -130,8 +130,9 @@ function migrate(done) {
 
 function seed(done) {
   const galleries = [
-    { slug: 'demo-gallery', name: 'Demo Gallery', bio: 'Welcome to the demo gallery showcasing placeholder artwork.', logo_url: randomAvatar() },
-    { slug: 'city-gallery', name: 'City Gallery', bio: 'Featuring modern works from local artists.', logo_url: randomAvatar() }
+    { slug: 'demo-gallery', name: 'Demo Gallery', bio: 'Welcome to the demo gallery showcasing placeholder artwork.', contact_email: 'info@demogallery.example', phone: '555-000-0001', logo_url: randomAvatar() },
+    { slug: 'city-gallery', name: 'City Gallery', bio: 'Featuring modern works from local artists.', contact_email: 'hello@citygallery.example', phone: '555-000-0002', logo_url: randomAvatar() },
+    { slug: 'western-gallery', name: 'Western Gallery', bio: 'Frontier art and desert dreams.', contact_email: 'hello@western.example', phone: '555-867-5309', logo_url: '/line-logo.svg' }
   ];
   const artists = [
     { id: 'artist1', gallery_slug: 'demo-gallery', name: 'Jane Doe', bio: 'An abstract artist exploring color and form.', bioImageUrl: randomAvatar(), fullBio: 'Jane Doe investigates the emotional resonance of color and shape.\n\nHer canvases challenge viewers to find their own narratives within abstract forms.' },
@@ -140,11 +141,15 @@ function seed(done) {
     { id: 'artist4', gallery_slug: 'demo-gallery', name: 'Liam Nguyen', bio: 'Digital artist focusing on surreal landscapes.', bioImageUrl: randomAvatar(), fullBio: 'Liam Nguyen crafts dreamlike vistas with a digital brush.\n\nHe blends reality and imagination to transport viewers beyond the ordinary.' },
     { id: 'artist5', gallery_slug: 'city-gallery', name: 'Sophia Martinez', bio: 'Sculptor merging modern and classical motifs.', bioImageUrl: randomAvatar(), fullBio: 'Sophia Martinez merges historical influences with contemporary design.\n\nHer sculptures echo timeless narratives through modern materials.' },
     { id: 'artist6', gallery_slug: 'city-gallery', name: 'Luca Green', bio: 'Painter capturing urban life with bold colors.', bioImageUrl: randomAvatar(), fullBio: 'Luca Green paints bustling streets with vibrant energy.\n\nHis dynamic brushwork celebrates the rhythm of city living.' },
-    { id: 'artist7', gallery_slug: 'city-gallery', name: 'Ava Patel', bio: 'Digital artist blending technology and emotion.', bioImageUrl: randomAvatar(), fullBio: 'Ava Patel explores human connection through digital mediums.\n\nHer creations blur the line between code and compassion.' }
+    { id: 'artist7', gallery_slug: 'city-gallery', name: 'Ava Patel', bio: 'Digital artist blending technology and emotion.', bioImageUrl: randomAvatar(), fullBio: 'Ava Patel explores human connection through digital mediums.\n\nHer creations blur the line between code and compassion.' },
+    { id: 'sierra', gallery_slug: 'western-gallery', name: 'Sierra Blaze', bio: 'Painter of fiery desert sunsets.', bioImageUrl: randomAvatar(), fullBio: 'Sierra Blaze captures the burnished skies of the frontier.\n\nHer canvases glow with sun and sand.' },
+    { id: 'dusty', gallery_slug: 'western-gallery', name: 'Dusty Canyon', bio: 'Sculptor shaping metal and wind.', bioImageUrl: randomAvatar(), fullBio: 'Dusty Canyon bends reclaimed steel into swirling desert forms.\n\nEach piece hums with the whisper of arid breezes.' },
+    { id: 'mesa', gallery_slug: 'western-gallery', name: 'Mesa Lark', bio: 'Watercolorist of quiet mesas.', bioImageUrl: randomAvatar(), fullBio: 'Mesa Lark washes paper with tranquil pigments.\n\nHer work celebrates the soft songs of high desert mornings.' },
+    { id: 'ridge', gallery_slug: 'western-gallery', name: 'Ridge Walker', bio: 'Digital artist reimagining frontier myths.', bioImageUrl: randomAvatar(), fullBio: 'Ridge Walker rides the line between code and cowboy lore.\n\nHis pixels gallop through cosmic prairies.' }
   ];
 
-  const galleryStmt = db.prepare('INSERT INTO galleries (slug, name, bio, logo_url) VALUES (?,?,?,?)');
-  galleries.forEach(g => galleryStmt.run(g.slug, g.name, g.bio, g.logo_url));
+  const galleryStmt = db.prepare('INSERT INTO galleries (slug, name, bio, contact_email, phone, logo_url) VALUES (?,?,?,?,?,?)');
+  galleries.forEach(g => galleryStmt.run(g.slug, g.name, g.bio, g.contact_email, g.phone, g.logo_url));
   galleryStmt.finalize();
 
   const artistStmt = db.prepare('INSERT INTO artists (id, gallery_slug, name, bio, bioImageUrl, fullBio) VALUES (?,?,?,?,?,?)');
@@ -156,7 +161,7 @@ function seed(done) {
   userStmt.run('Demo User', 'demouser', demoHash, 'artist', 'taos');
   userStmt.finalize();
 
-  const artworkStmt = db.prepare('INSERT INTO artworks (id, artist_id, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, hide_collected, featured, isVisible, isFeatured, description, framed, ready_to_hang) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
+  const artworkStmt = db.prepare('INSERT INTO artworks (id, artist_id, gallery_slug, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, hide_collected, featured, isVisible, isFeatured, description, framed, ready_to_hang) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
 
   function randomImage() {
     const id = Math.floor(Math.random() * 90) + 10; // 10-99
@@ -190,6 +195,25 @@ function seed(done) {
     'A contemplative work examining space.'
   ];
 
+  const customArtworks = {
+    sierra: [
+      { id: 'sierra-art1', title: 'Sunset Over Sage', medium: 'Oil', description: 'Glowing hues chase twilight across open plains.' },
+      { id: 'sierra-art2', title: 'Ember Trail', medium: 'Oil', description: 'Footprints of fire fading into night.' }
+    ],
+    dusty: [
+      { id: 'dusty-art1', title: 'Whistling Gulch', medium: 'Sculpture', description: 'Metal and wind shaped into canyon whispers.' },
+      { id: 'dusty-art2', title: 'Rust and Stardust', medium: 'Mixed Media', description: 'Found relics fused with desert starlight.' }
+    ],
+    mesa: [
+      { id: 'mesa-art1', title: 'Quiet Mesa Morning', medium: 'Watercolor', description: 'Soft washes catching first light over mesas.' },
+      { id: 'mesa-art2', title: 'Cactus Serenade', medium: 'Watercolor', description: 'Prickly pear blooms singing in color.' }
+    ],
+    ridge: [
+      { id: 'ridge-art1', title: 'Pixel Pony Express', medium: 'Digital', description: 'Neon riders racing across virtual plains.' },
+      { id: 'ridge-art2', title: 'Lassoed Nebula', medium: 'Digital', description: 'Stars corralled into a cosmic rodeo.' }
+    ]
+  };
+
   function generateTitle(artist, index) {
     const a = adjectives[(index + artist.id.length) % adjectives.length];
     const n = nouns[(index * 3 + artist.id.length) % nouns.length];
@@ -197,17 +221,27 @@ function seed(done) {
   }
 
   artists.forEach(artist => {
-    for (let i = 0; i < 8; i++) {
-      const img = randomImage();
-      const artId = `${artist.id}-art${i + 1}`;
-      const title = generateTitle(artist, i);
-      const medium = mediums[i % mediums.length];
-      const status = i === 0 ? 'collected' : 'available';
-      const isFeatured = i === 0 ? 1 : 0;
-      const description = descriptions[(i + artist.id.length) % descriptions.length];
-      const framed = i % 2 === 0 ? 1 : 0;
-      const ready = (i + 1) % 2 === 0 ? 1 : 0;
-      artworkStmt.run(artId, artist.id, title, medium, '24x36', randomPrice(), img, img, img, status, 0, 0, 1, isFeatured, description, framed, ready);
+    const custom = customArtworks[artist.id];
+    if (custom) {
+      custom.forEach((art, i) => {
+        const img = randomImage();
+        const status = 'available';
+        const isFeatured = i === 0 ? 1 : 0;
+        artworkStmt.run(art.id, artist.id, artist.gallery_slug, art.title, art.medium, '24x36', randomPrice(), img, img, img, status, 0, 0, 1, isFeatured, art.description, 1, 0);
+      });
+    } else {
+      for (let i = 0; i < 8; i++) {
+        const img = randomImage();
+        const artId = `${artist.id}-art${i + 1}`;
+        const title = generateTitle(artist, i);
+        const medium = mediums[i % mediums.length];
+        const status = i === 0 ? 'collected' : 'available';
+        const isFeatured = i === 0 ? 1 : 0;
+        const description = descriptions[(i + artist.id.length) % descriptions.length];
+        const framed = i % 2 === 0 ? 1 : 0;
+        const ready = (i + 1) % 2 === 0 ? 1 : 0;
+        artworkStmt.run(artId, artist.id, artist.gallery_slug, title, medium, '24x36', randomPrice(), img, img, img, status, 0, 0, 1, isFeatured, description, framed, ready);
+      }
     }
   });
 

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -1,7 +1,7 @@
 const { db } = require('./db');
 
 function getGallery(slug, cb) {
-  const galleryQuery = 'SELECT slug, name, bio, logo_url FROM galleries WHERE slug = ?';
+  const galleryQuery = 'SELECT slug, name, bio, logo_url, contact_email, phone FROM galleries WHERE slug = ?';
   db.get(galleryQuery, [slug], (err, gallery) => {
     if (err || !gallery) return cb(err || new Error('Not found'));
     db.all('SELECT * FROM artists WHERE gallery_slug = ?', [slug], (err2, artists) => {

--- a/public/line-logo.svg
+++ b/public/line-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <line x1="10" y1="10" x2="90" y2="10" stroke="black" stroke-width="5" stroke-linecap="round" />
+</svg>

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -127,6 +127,15 @@ test('gallery page lists multiple artists', async () => {
   assert.ok(matches.length >= 2);
 });
 
+test('western gallery exposes contact info', async () => {
+  const port = server.address().port;
+  const { statusCode, body } = await httpGet(`http://localhost:${port}/western-gallery`);
+  assert.strictEqual(statusCode, 200);
+  assert.match(body, /Western Gallery/);
+  assert.match(body, /hello@western\.example/);
+  assert.match(body, /555-867-5309/);
+});
+
 test('dashboard redirects to login when not authenticated', async () => {
   const port = server.address().port;
   const { statusCode, headers } = await httpGet(`http://localhost:${port}/dashboard`);

--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -16,6 +16,9 @@
 
   <main class="max-w-4xl mx-auto p-6">
     <header class="text-center mb-12">
+      <% if (gallery.logo_url) { %>
+        <img src="<%= gallery.logo_url %>" alt="<%= gallery.name %> logo" class="mx-auto mb-4 w-16 h-16 object-contain">
+      <% } %>
       <h1 class="text-xl md:text-2xl font-bold mb-4"><%= artist.name %></h1>
       <p class="text-base text-gray-600"><%= artist.bio %></p>
     </header>
@@ -72,6 +75,16 @@
   </main>
 
   <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <% if (gallery.contact_email || gallery.phone) { %>
+      <div class="mb-2 text-sm">
+        <% if (gallery.contact_email) { %>
+          <p>Contact: <a href="mailto:<%= gallery.contact_email %>" class="underline"><%= gallery.contact_email %></a></p>
+        <% } %>
+        <% if (gallery.phone) { %>
+          <p>Phone: <%= gallery.phone %></p>
+        <% } %>
+      </div>
+    <% } %>
     <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
   </footer>
   <script src="/js/fade-in.js"></script>

--- a/views/artwork-detail.ejs
+++ b/views/artwork-detail.ejs
@@ -16,7 +16,10 @@
   </nav>
 
   <main class="max-w-5xl mx-auto p-6">
-    <section class="mb-6">
+    <section class="mb-6 text-center">
+      <% if (gallery.logo_url) { %>
+        <img src="<%= gallery.logo_url %>" alt="<%= gallery.name %> logo" class="mx-auto mb-4 w-16 h-16 object-contain">
+      <% } %>
       <div class="relative">
         <img id="main-image" src="<%= artwork.imageStandard %>" alt="<%= artwork.title %>" class="mx-auto max-w-full cursor-zoom-in transition-opacity duration-700 opacity-0" loading="lazy" data-fade>
         <div class="absolute bottom-2 right-2 flex space-x-2">
@@ -112,6 +115,16 @@
   </main>
 
   <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <% if (gallery.contact_email || gallery.phone) { %>
+      <div class="mb-2 text-sm">
+        <% if (gallery.contact_email) { %>
+          <p>Contact: <a href="mailto:<%= gallery.contact_email %>" class="underline"><%= gallery.contact_email %></a></p>
+        <% } %>
+        <% if (gallery.phone) { %>
+          <p>Phone: <%= gallery.phone %></p>
+        <% } %>
+      </div>
+    <% } %>
     <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
   </footer>
   <script src="/js/fade-in.js"></script>

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -20,6 +20,9 @@
 
   <main class="max-w-4xl mx-auto p-6">
     <header class="text-center mb-12">
+      <% if (gallery.logo_url) { %>
+        <img src="<%= gallery.logo_url %>" alt="<%= gallery.name %> logo" class="mx-auto mb-4 w-16 h-16 object-contain">
+      <% } %>
       <h1 class="text-xl md:text-2xl font-bold mb-4"><%= gallery.name %></h1>
       <p class="text-base text-gray-600"><%= gallery.bio %></p>
     </header>
@@ -63,6 +66,16 @@
   </main>
 
   <footer class="text-center py-6 border-t border-gray-200 mt-12">
+    <% if (gallery.contact_email || gallery.phone) { %>
+      <div class="mb-2 text-sm">
+        <% if (gallery.contact_email) { %>
+          <p>Contact: <a href="mailto:<%= gallery.contact_email %>" class="underline"><%= gallery.contact_email %></a></p>
+        <% } %>
+        <% if (gallery.phone) { %>
+          <p>Phone: <%= gallery.phone %></p>
+        <% } %>
+      </div>
+    <% } %>
     <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
   </footer>
   <script src="/js/fade-in.js"></script>


### PR DESCRIPTION
## Summary
- seed new "Western Gallery" with four themed artists, custom artworks, contact details, and a minimalist line logo
- surface gallery contact email and phone on gallery, artist, and artwork pages while displaying the gallery logo
- test Western Gallery route to ensure contact information appears

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e48ecdf08320b3433446f2826184