### PR TITLE
refactor: apply route-level CSRF protection

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const router = express.Router();
+const csrf = require('csurf');
+const csrfProtection = csrf();
 const { createUser, findUserByUsername } = require('../models/userModel');
 const { createArtist } = require('../models/artistModel');
 const { createGallery } = require('../models/galleryModel');
@@ -63,26 +65,30 @@ function signupHandler(role) {
   };
 }
 
-router.get('/signup', (req, res) => {
+router.get('/signup', csrfProtection, (req, res) => {
+  res.locals.csrfToken = req.csrfToken();
   res.render('signup/index');
 });
 
-router.get('/signup/artist', (req, res) => {
+router.get('/signup/artist', csrfProtection, (req, res) => {
+  res.locals.csrfToken = req.csrfToken();
   res.render('signup/artist');
 });
 
-router.get('/signup/gallery', (req, res) => {
+router.get('/signup/gallery', csrfProtection, (req, res) => {
+  res.locals.csrfToken = req.csrfToken();
   res.render('signup/gallery');
 });
 
-router.post('/signup/artist', signupHandler('artist'));
-router.post('/signup/gallery', signupHandler('gallery'));
+router.post('/signup/artist', csrfProtection, signupHandler('artist'));
+router.post('/signup/gallery', csrfProtection, signupHandler('gallery'));
 
-router.get('/login', (req, res) => {
+router.get('/login', csrfProtection, (req, res) => {
+  res.locals.csrfToken = req.csrfToken();
   res.render('login');
 });
 
-router.post('/login', (req, res) => {
+router.post('/login', csrfProtection, (req, res) => {
   const { username, password } = req.body;
   if (!username || !password) {
     req.flash('error', 'All fields are required');

--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -4,6 +4,8 @@ const path = require('path');
 const fs = require('fs');
 const multer = require('multer');
 const { requireRole } = require('../../middleware/auth');
+const csrf = require('csurf');
+const csrfProtection = csrf();
 let Jimp;
 try {
   Jimp = require('jimp');
@@ -76,7 +78,8 @@ function slugify(str) {
   return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
 }
 
-router.get('/', requireRole('artist'), (req, res) => {
+router.get('/', requireRole('artist'), csrfProtection, (req, res) => {
+  res.locals.csrfToken = req.csrfToken();
   getCollectionsByArtist(req.session.user.id, (err, collections) => {
     getArtworksByArtist(req.session.user.id, (err2, artworks) => {
       getArtistById(req.session.user.id, (err3, artist) => {
@@ -95,7 +98,7 @@ router.get('/collections', requireRole('artist'), (req, res) => {
   res.redirect('/dashboard/artist');
 });
 
-router.post('/collections', requireRole('artist'), (req, res) => {
+router.post('/collections', requireRole('artist'), csrfProtection, (req, res) => {
   const { name } = req.body;
   const slug = slugify(name);
   createCollection(name, req.session.user.id, slug, err => {
@@ -104,7 +107,7 @@ router.post('/collections', requireRole('artist'), (req, res) => {
   });
 });
 
-router.post('/collections/:id', requireRole('artist'), (req, res) => {
+router.post('/collections/:id', requireRole('artist'), csrfProtection, (req, res) => {
   const { name } = req.body;
   updateCollection(req.params.id, name, err => {
     if (err) req.flash('error', 'Could not update collection');
@@ -112,13 +115,8 @@ router.post('/collections/:id', requireRole('artist'), (req, res) => {
   });
 });
 
-router.post('/profile', requireRole('artist'), (req, res) => {
-  upload.single('bioImageFile')(req, res, async err => {
-    if (err) {
-      console.error(err);
-      req.flash('error', err.message);
-      return res.redirect('/dashboard/artist');
-    }
+router.post('/profile', requireRole('artist'), upload.single('bioImageFile'), csrfProtection, async (req, res) => {
+  try {
     const { name, bio, fullBio, bioImageUrl } = req.body;
     if (!name || !bio) {
       req.flash('error', 'Name and short bio are required');
@@ -128,78 +126,69 @@ router.post('/profile', requireRole('artist'), (req, res) => {
       req.flash('error', 'Choose either an upload or a URL');
       return res.redirect('/dashboard/artist');
     }
-    try {
-      let avatarUrl = bioImageUrl;
-      if (req.file) {
-        const images = await processImages(req.file);
-        avatarUrl = images.imageStandard;
-      }
-      updateArtist(req.session.user.id, name, bio, fullBio || '', avatarUrl || '', err2 => {
-        if (err2) {
-          console.error(err2);
-          req.flash('error', 'Could not update profile');
-        } else {
-          req.flash('success', 'Profile updated');
-        }
-        res.redirect('/dashboard/artist');
-      });
-    } catch (procErr) {
-      console.error(procErr);
-      req.flash('error', 'Image processing failed');
-      res.redirect('/dashboard/artist');
+    let avatarUrl = bioImageUrl;
+    if (req.file) {
+      const images = await processImages(req.file);
+      avatarUrl = images.imageStandard;
     }
-  });
-});
-
-router.post('/artworks', requireRole('artist'), (req, res) => {
-  upload.single('imageFile')(req, res, async err => {
-    if (err) {
-      console.error(err);
-      req.flash('error', err.message);
-      return res.redirect('/dashboard/artist');
-    }
-    const { title, medium, dimensions, price, description, framed, readyToHang, imageUrl, action = 'upload' } = req.body;
-    if (!title || !medium || !dimensions) {
-      req.flash('error', 'All fields are required');
-      return res.redirect('/dashboard/artist');
-    }
-    if (action !== 'save') {
-      if (req.file && imageUrl) {
-        req.flash('error', 'Choose either an upload or a URL');
-        return res.redirect('/dashboard/artist');
-      }
-      if (!req.file && !imageUrl) {
-        req.flash('error', 'Image is required');
-        return res.redirect('/dashboard/artist');
-      }
-    }
-    try {
-      let images;
-      if (req.file) {
-        images = await processImages(req.file);
-      } else if (imageUrl) {
-        images = { imageFull: imageUrl, imageStandard: imageUrl, imageThumb: imageUrl };
+    updateArtist(req.session.user.id, name, bio, fullBio || '', avatarUrl || '', err2 => {
+      if (err2) {
+        console.error(err2);
+        req.flash('error', 'Could not update profile');
       } else {
-        images = { imageFull: '', imageStandard: '', imageThumb: '' };
+        req.flash('success', 'Profile updated');
       }
-      createArtwork(req.session.user.id, title, medium, dimensions, price, description, framed === 'on', readyToHang === 'on', images, createErr => {
-        if (createErr) {
-          console.error(createErr);
-          req.flash('error', 'Could not create artwork');
-        } else {
-          req.flash('success', action === 'save' ? 'Artwork saved' : 'Artwork added');
-        }
-        res.redirect('/dashboard/artist');
-      });
-    } catch (procErr) {
-      console.error(procErr);
-      req.flash('error', 'Image processing failed');
       res.redirect('/dashboard/artist');
-    }
-  });
+    });
+  } catch (err) {
+    console.error(err);
+    req.flash('error', 'Image processing failed');
+    res.redirect('/dashboard/artist');
+  }
 });
 
-router.post('/artworks/:id/collection', requireRole('artist'), (req, res) => {
+router.post('/artworks', requireRole('artist'), upload.single('imageFile'), csrfProtection, async (req, res) => {
+  const { title, medium, dimensions, price, description, framed, readyToHang, imageUrl, action = 'upload' } = req.body;
+  if (!title || !medium || !dimensions) {
+    req.flash('error', 'All fields are required');
+    return res.redirect('/dashboard/artist');
+  }
+  if (action !== 'save') {
+    if (req.file && imageUrl) {
+      req.flash('error', 'Choose either an upload or a URL');
+      return res.redirect('/dashboard/artist');
+    }
+    if (!req.file && !imageUrl) {
+      req.flash('error', 'Image is required');
+      return res.redirect('/dashboard/artist');
+    }
+  }
+  try {
+    let images;
+    if (req.file) {
+      images = await processImages(req.file);
+    } else if (imageUrl) {
+      images = { imageFull: imageUrl, imageStandard: imageUrl, imageThumb: imageUrl };
+    } else {
+      images = { imageFull: '', imageStandard: '', imageThumb: '' };
+    }
+    createArtwork(req.session.user.id, title, medium, dimensions, price, description, framed === 'on', readyToHang === 'on', images, createErr => {
+      if (createErr) {
+        console.error(createErr);
+        req.flash('error', 'Could not create artwork');
+      } else {
+        req.flash('success', action === 'save' ? 'Artwork saved' : 'Artwork added');
+      }
+      res.redirect('/dashboard/artist');
+    });
+  } catch (err) {
+    console.error(err);
+    req.flash('error', 'Image processing failed');
+    res.redirect('/dashboard/artist');
+  }
+});
+
+router.post('/artworks/:id/collection', requireRole('artist'), csrfProtection, (req, res) => {
   const { collection_id } = req.body;
   updateArtworkCollection(req.params.id, collection_id || null, err => {
     if (err) req.flash('error', 'Could not update artwork');
@@ -212,6 +201,11 @@ router.use((err, req, res, next) => {
   if (err.code === 'EBADCSRFTOKEN') {
     console.error('CSRF token mismatch on artist route', err);
     return res.status(403).send('Invalid CSRF token');
+  }
+  if (err.code === 'LIMIT_FILE_SIZE' || err.message === 'Only JPG, PNG, or HEIC images are allowed') {
+    console.error(err);
+    req.flash('error', err.code === 'LIMIT_FILE_SIZE' ? 'File too large' : err.message);
+    return res.redirect('/dashboard/artist');
   }
   next(err);
 });

--- a/server.js
+++ b/server.js
@@ -26,7 +26,6 @@ try {
     next();
   };
 }
-const csrf = require('csurf');
 const { initialize, migrate } = require('./models/db');
 
 function simulateAuth(req, res, next) {
@@ -69,7 +68,6 @@ if (SQLiteStore) {
   sessionOptions.store = new SQLiteStore();
 }
 app.use(session(sessionOptions));
-app.use(csrf());
 
 // Flash messages using connect-flash or fallback implementation
 app.use(flash());
@@ -80,7 +78,6 @@ app.use((req, res, next) => {
   req.user = req.session.user;
   res.locals.user = req.user;
   res.locals.flash = req.flash();
-  res.locals.csrfToken = req.csrfToken();
   next();
 });
 


### PR DESCRIPTION
## Summary
- shift CSRF handling from a global middleware to route-level protection
- add CSRF tokens to auth and dashboard pages, including upload and artwork routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ea44a2008320b9987a39eaffe55f