### PR TITLE
Allow artists to feature artworks

### DIFF
--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -36,7 +36,7 @@ function updateArtworkCollection(id, collectionId, cb) {
   db.run('UPDATE artworks SET collection_id = ? WHERE id = ?', [collectionId, id], cb);
 }
 
-function createArtwork(artistId, title, medium, dimensions, price, description, framed, readyToHang, images, cb) {
+function createArtwork(artistId, title, medium, dimensions, price, description, framed, readyToHang, images, isFeatured, cb) {
   db.get('SELECT gallery_slug FROM artists WHERE id = ?', [artistId], (err, row) => {
     if (err || !row) return cb(err || new Error('Artist not found'));
     const id = 'art_' + Date.now();
@@ -55,7 +55,7 @@ function createArtwork(artistId, title, medium, dimensions, price, description, 
       images.imageThumb,
       'available',
       1,
-      0,
+      isFeatured ? 1 : 0,
       description || '',
       framed ? 1 : 0,
       readyToHang ? 1 : 0

--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -148,7 +148,7 @@ router.post('/profile', requireRole('artist'), upload.single('bioImageFile'), cs
 });
 
 router.post('/artworks', requireRole('artist'), upload.single('imageFile'), csrfProtection, async (req, res) => {
-  const { title, medium, dimensions, price, description, framed, readyToHang, imageUrl, action = 'upload' } = req.body;
+  const { title, medium, dimensions, price, description, framed, readyToHang, isFeatured, imageUrl, action = 'upload' } = req.body;
   if (!title || !medium || !dimensions) {
     req.flash('error', 'All fields are required');
     return res.redirect('/dashboard/artist');
@@ -172,7 +172,18 @@ router.post('/artworks', requireRole('artist'), upload.single('imageFile'), csrf
     } else {
       images = { imageFull: '', imageStandard: '', imageThumb: '' };
     }
-    createArtwork(req.session.user.id, title, medium, dimensions, price, description, framed === 'on', readyToHang === 'on', images, createErr => {
+    createArtwork(
+      req.session.user.id,
+      title,
+      medium,
+      dimensions,
+      price,
+      description,
+      framed === 'on',
+      readyToHang === 'on',
+      images,
+      isFeatured === 'on',
+      createErr => {
       if (createErr) {
         console.error(createErr);
         req.flash('error', 'Could not create artwork');
@@ -180,7 +191,8 @@ router.post('/artworks', requireRole('artist'), upload.single('imageFile'), csrf
         req.flash('success', action === 'save' ? 'Artwork saved' : 'Artwork added');
       }
       res.redirect('/dashboard/artist');
-    });
+    }
+    );
   } catch (err) {
     console.error(err);
     req.flash('error', 'Image processing failed');

--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -59,6 +59,7 @@
         <textarea name="description" placeholder="Description" class="border border-gray-300 rounded px-2 py-1 w-full"></textarea>
         <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="framed" class="border-gray-300">Framed</label>
         <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="readyToHang" class="border-gray-300">Ready to Hang</label>
+        <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="isFeatured" class="border-gray-300">Featured</label>
         <input type="file" name="imageFile" accept="image/*" class="border border-gray-300 rounded px-2 py-1 w-full">
         <input type="url" name="imageUrl" placeholder="Image URL" class="border border-gray-300 rounded px-2 py-1 w-full">
         <p class="text-xs text-gray-500">Provide an image file or a URL</p>


### PR DESCRIPTION
## Summary
- Restore ability for artists to mark new artworks as featured via a checkbox on the dashboard form.
- Persist featured flag when creating an artwork so highlighted pieces surface in gallery and artist views.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890f4ad5dd08320b30e184da96a2fc5