### PR TITLE
Add dashboard links to public artist and gallery pages

### DIFF
--- a/views/account.ejs
+++ b/views/account.ejs
@@ -13,7 +13,7 @@
     <p class="mb-2 text-center">Username: <strong><%= user.username %></strong></p>
     <p class="mb-4 text-center">Role: <strong><%= user.role %></strong></p>
     <% if (user.role === 'gallery') { %>
-      <p class="mb-4 text-center">Public gallery URL: <a href="/<%= user.username %>" class="text-blue-600 underline">/<%= user.username %></a></p>
+      <p class="mb-4 text-center">Public gallery URL: <a href="/<%= user.username %>" class="text-blue-600 underline" target="_blank" rel="noopener noreferrer">/<%= user.username %></a></p>
     <% } else if (user.role === 'artist') { %>
       <p class="mb-4 text-center">Manage your portfolio from the dashboard.</p>
     <% } %>

--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -16,6 +16,13 @@
     <% if (flash.success && flash.success.length) { %>
       <p class="text-green-600 mb-4"><%= flash.success[0] %></p>
     <% } %>
+    <% if (artist.gallery_slug) { %>
+      <p class="mb-4 text-center">Your public page is available at
+        <a href="/<%= artist.gallery_slug %>/artists/<%= artist.id %>" class="text-blue-600 underline" target="_blank" rel="noopener noreferrer">
+          /<%= artist.gallery_slug %>/artists/<%= artist.id %>
+        </a>
+      </p>
+    <% } %>
     <section class="mb-8">
       <h2 class="text-xl font-semibold mb-4">Profile</h2>
       <form method="POST" action="/dashboard/artist/profile" enctype="multipart/form-data" class="space-y-2">

--- a/views/dashboard/gallery.ejs
+++ b/views/dashboard/gallery.ejs
@@ -16,6 +16,11 @@
     <% if (flash.success && flash.success.length) { %>
       <p class="text-green-600 mb-4"><%= flash.success[0] %></p>
     <% } %>
+    <p class="mb-4 text-center">Your public gallery is available at
+      <a href="/<%= user.username %>" class="text-blue-600 underline" target="_blank" rel="noopener noreferrer">
+        /<%= user.username %>
+      </a>
+    </p>
     <% const dashBase = '/dashboard'; %>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
       <a href="<%= dashBase %>/galleries" class="p-6 border rounded flex flex-col items-center hover:bg-gray-50">My Gallery</a>


### PR DESCRIPTION
## Summary
- Add link on artist dashboard to open public artist page in a new tab
- Add link on gallery dashboard to open public gallery page in a new tab
- Ensure account page gallery URL opens in a new tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890fd661a3c8320b7c5a4e0c815a178