### PR TITLE
Fix profile avatar upload validation

### DIFF
--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -117,7 +117,7 @@ router.post('/collections/:id', requireRole('artist'), csrfProtection, (req, res
 
 router.post('/profile', requireRole('artist'), upload.single('bioImageFile'), csrfProtection, async (req, res) => {
   try {
-    const { name, bio, fullBio, bioImageUrl } = req.body;
+    const { name, bio, fullBio, bioImageUrl, currentBioImageUrl } = req.body;
     if (!name || !bio) {
       req.flash('error', 'Name and short bio are required');
       return res.redirect('/dashboard/artist');
@@ -126,10 +126,14 @@ router.post('/profile', requireRole('artist'), upload.single('bioImageFile'), cs
       req.flash('error', 'Choose either an upload or a URL');
       return res.redirect('/dashboard/artist');
     }
-    let avatarUrl = bioImageUrl;
+    let avatarUrl;
     if (req.file) {
       const images = await processImages(req.file);
       avatarUrl = images.imageStandard;
+    } else if (bioImageUrl) {
+      avatarUrl = bioImageUrl;
+    } else {
+      avatarUrl = currentBioImageUrl;
     }
     updateArtist(req.session.user.id, name, bio, fullBio || '', avatarUrl || '', err2 => {
       if (err2) {

--- a/views/dashboard/artist.ejs
+++ b/views/dashboard/artist.ejs
@@ -24,7 +24,8 @@
         <textarea name="bio" placeholder="Short bio" required class="border border-gray-300 rounded px-2 py-1 w-full"><%= artist.bio || '' %></textarea>
         <textarea name="fullBio" placeholder="Full bio" class="border border-gray-300 rounded px-2 py-1 w-full"><%= artist.fullBio || '' %></textarea>
         <input type="file" name="bioImageFile" accept="image/*" class="border border-gray-300 rounded px-2 py-1 w-full">
-        <input type="url" name="bioImageUrl" placeholder="Bio image URL" value="<%= artist.bioImageUrl || '' %>" class="border border-gray-300 rounded px-2 py-1 w-full">
+        <input type="hidden" name="currentBioImageUrl" value="<%= artist.bioImageUrl || '' %>">
+        <input type="url" name="bioImageUrl" placeholder="Bio image URL" value="<%= artist.bioImageUrl && artist.bioImageUrl.startsWith('http') ? artist.bioImageUrl : '' %>" class="border border-gray-300 rounded px-2 py-1 w-full">
         <p class="text-xs text-gray-500">Provide an image file or a URL</p>
         <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded">Save Profile</button>
       </form>


### PR DESCRIPTION
## Summary
- Prevent uploaded avatar paths from populating the offsite URL field
- Preserve existing avatar when no new file or URL is provided
- Restore uploads directory placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890fe11a9888320a8865ad1cd1af181