### PR TITLE
Fix artist dashboard link

### DIFF
--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -5,8 +5,10 @@
     <% if (user && user.role !== 'artist') { %>
       <a href="/dashboard/galleries" class="hover:underline">Galleries</a>
       <a href="/dashboard/artists" class="hover:underline">Artists</a>
+      <a href="/dashboard/artworks" class="hover:underline">Artworks</a>
+    <% } else if (user) { %>
+      <a href="/dashboard/artist" class="hover:underline">Artworks</a>
     <% } %>
-    <a href="/dashboard/artworks" class="hover:underline">Artworks</a>
     <% if (user) { %>
       <a href="/account" class="hover:underline">Account</a>
     <% } %>


### PR DESCRIPTION
## Summary
- Adjust navbar to send artists to their own dashboard for Artworks
- Keep artworks link for admin and galleries only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890fecd630c8320b8b661e5d416396a