### PR TITLE
Add archived flags for artists and artworks

### DIFF
--- a/migrations/003_add_archive.sql
+++ b/migrations/003_add_archive.sql
@@ -1,0 +1,3 @@
+-- Add archived columns to artists and artworks
+ALTER TABLE artists ADD COLUMN IF NOT EXISTS archived INTEGER DEFAULT 0;
+ALTER TABLE artworks ADD COLUMN IF NOT EXISTS archived INTEGER DEFAULT 0;

--- a/models/db.js
+++ b/models/db.js
@@ -31,7 +31,8 @@ function initialize() {
       bio_short TEXT,
       bio_full TEXT,
       portrait_url TEXT,
-      gallery_id TEXT
+      gallery_id TEXT,
+      archived INTEGER DEFAULT 0
     )`);
 
     db.run(`CREATE TABLE IF NOT EXISTS users (
@@ -69,7 +70,8 @@ function initialize() {
       isFeatured INTEGER DEFAULT 0,
       description TEXT,
       framed INTEGER DEFAULT 0,
-      ready_to_hang INTEGER DEFAULT 0
+      ready_to_hang INTEGER DEFAULT 0,
+      archived INTEGER DEFAULT 0
     )`);
 
     db.get('SELECT COUNT(*) as count FROM galleries', (err, row) => {


### PR DESCRIPTION
## Summary
- add migration to append `archived` column to `artists` and `artworks`
- include `archived` default flag in table creation for fresh databases
- migrations continue to run on startup to sync existing databases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68910099e2448320aea2a127c6cfc9cc