### PR TITLE
Filter archived artists and artworks in gallery views

### DIFF
--- a/models/artistModel.js
+++ b/models/artistModel.js
@@ -1,9 +1,12 @@
 const { db } = require('./db');
 
 function getArtist(gallerySlug, id, cb) {
-  db.get('SELECT * FROM artists WHERE id = ? AND gallery_slug = ?', [id, gallerySlug], (err, artist) => {
+  const artistSql =
+    'SELECT * FROM artists WHERE id = ? AND gallery_slug = ? AND archived = 0';
+  db.get(artistSql, [id, gallerySlug], (err, artist) => {
     if (err || !artist) return cb(err || new Error('Not found'));
-    db.all('SELECT * FROM artworks WHERE artist_id = ?', [id], (err2, artworks) => {
+    const artSql = 'SELECT * FROM artworks WHERE artist_id = ? AND archived = 0';
+    db.all(artSql, [id], (err2, artworks) => {
       if (err2) return cb(err2);
       artist.artworks = artworks || [];
       cb(null, artist);
@@ -25,4 +28,19 @@ function updateArtist(id, name, bio, fullBio, bioImageUrl, cb) {
   db.run(stmt, [name, bio, fullBio, bioImageUrl, id], cb);
 }
 
-module.exports = { getArtist, createArtist, getArtistById, updateArtist };
+function archiveArtist(id, cb) {
+  db.run('UPDATE artists SET archived = 1 WHERE id = ?', [id], cb);
+}
+
+function unarchiveArtist(id, cb) {
+  db.run('UPDATE artists SET archived = 0 WHERE id = ?', [id], cb);
+}
+
+module.exports = {
+  getArtist,
+  createArtist,
+  getArtistById,
+  updateArtist,
+  archiveArtist,
+  unarchiveArtist
+};

--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -3,7 +3,8 @@ const { db } = require('./db');
 function getArtwork(gallerySlug, id, cb) {
   const query = `SELECT artworks.*, artists.gallery_slug, artists.id as artistId
                  FROM artworks JOIN artists ON artworks.artist_id = artists.id
-                 WHERE artworks.id = ? AND artists.gallery_slug = ?`;
+                 WHERE artworks.id = ? AND artists.gallery_slug = ?
+                 AND artworks.archived = 0 AND artists.archived = 0`;
   db.get(query, [id, gallerySlug], (err, row) => {
     if (err || !row) return cb(err || new Error('Not found'));
     const artwork = {
@@ -29,7 +30,7 @@ function getArtwork(gallerySlug, id, cb) {
 }
 
 function getArtworksByArtist(artistId, cb) {
-  db.all('SELECT * FROM artworks WHERE artist_id = ?', [artistId], cb);
+  db.all('SELECT * FROM artworks WHERE artist_id = ? AND archived = 0', [artistId], cb);
 }
 
 function updateArtworkCollection(id, collectionId, cb) {
@@ -64,4 +65,19 @@ function createArtwork(artistId, title, medium, dimensions, price, description, 
   });
 }
 
-module.exports = { getArtwork, getArtworksByArtist, updateArtworkCollection, createArtwork };
+function archiveArtwork(id, cb) {
+  db.run('UPDATE artworks SET archived = 1 WHERE id = ?', [id], cb);
+}
+
+function unarchiveArtwork(id, cb) {
+  db.run('UPDATE artworks SET archived = 0 WHERE id = ?', [id], cb);
+}
+
+module.exports = {
+  getArtwork,
+  getArtworksByArtist,
+  updateArtworkCollection,
+  createArtwork,
+  archiveArtwork,
+  unarchiveArtwork
+};

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -1,32 +1,72 @@
 const { db } = require('./db');
 
-function getGallery(slug, cb) {
-  const galleryQuery = 'SELECT slug, name, bio, logo_url, contact_email, phone FROM galleries WHERE slug = ?';
+function getGallery(slug, options, cb) {
+  if (typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+  const { includeArchivedArtists = false, includeArchivedArtworks = false } =
+    options || {};
+
+  const galleryQuery =
+    'SELECT slug, name, bio, logo_url, contact_email, phone FROM galleries WHERE slug = ?';
   db.get(galleryQuery, [slug], (err, gallery) => {
     if (err || !gallery) return cb(err || new Error('Not found'));
-    db.all('SELECT * FROM artists WHERE gallery_slug = ?', [slug], (err2, artists) => {
+    const artistCond = includeArchivedArtists ? '' : 'AND a.archived = 0';
+    const artworkCond = includeArchivedArtworks ? '' : 'AND w.archived = 0';
+    const sql = `SELECT a.id as artistId, a.name as artistName, a.bio, a.bioImageUrl, a.fullBio, a.archived as artistArchived,
+                        w.id as artworkId, w.title, w.medium, w.dimensions, w.price, w.imageFull, w.imageStandard, w.imageThumb,
+                        w.status, w.hide_collected, w.featured, w.isVisible, w.isFeatured, w.description, w.framed, w.ready_to_hang,
+                        w.archived as artworkArchived
+                 FROM artists a
+                 LEFT JOIN artworks w ON w.artist_id = a.id AND w.isVisible = 1 ${artworkCond}
+                 WHERE a.gallery_slug = ? ${artistCond}`;
+    db.all(sql, [slug], (err2, rows) => {
       if (err2) return cb(err2);
-      let remaining = artists.length;
+      const artistMap = {};
       const featured = [];
-      if (remaining === 0) {
-        gallery.artists = [];
-        gallery.featuredArtworks = [];
-        return cb(null, gallery);
-      }
-      artists.forEach(artist => {
-        db.all('SELECT * FROM artworks WHERE artist_id = ? AND isVisible = 1', [artist.id], (err3, artworks) => {
-          artist.artworks = artworks || [];
-          (artworks || []).forEach(a => {
-            a.artistName = artist.name;
-          });
-          featured.push(...(artworks || []).filter(a => a.isFeatured));
-          if (--remaining === 0) {
-            gallery.artists = artists;
-            gallery.featuredArtworks = featured;
-            cb(null, gallery);
-          }
-        });
+      rows.forEach(row => {
+        let artist = artistMap[row.artistId];
+        if (!artist) {
+          artist = {
+            id: row.artistId,
+            name: row.artistName,
+            bio: row.bio,
+            bioImageUrl: row.bioImageUrl,
+            fullBio: row.fullBio,
+            archived: row.artistArchived,
+            artworks: []
+          };
+          artistMap[row.artistId] = artist;
+        }
+        if (row.artworkId) {
+          const artwork = {
+            id: row.artworkId,
+            title: row.title,
+            medium: row.medium,
+            dimensions: row.dimensions,
+            price: row.price,
+            imageFull: row.imageFull,
+            imageStandard: row.imageStandard,
+            imageThumb: row.imageThumb,
+            status: row.status,
+            hide_collected: row.hide_collected,
+            featured: row.featured,
+            isVisible: row.isVisible,
+            isFeatured: row.isFeatured,
+            description: row.description,
+            framed: row.framed,
+            readyToHang: row.ready_to_hang,
+            archived: row.artworkArchived,
+            artistName: row.artistName
+          };
+          artist.artworks.push(artwork);
+          if (artwork.isFeatured) featured.push(artwork);
+        }
       });
+      gallery.artists = Object.values(artistMap);
+      gallery.featuredArtworks = featured;
+      cb(null, gallery);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Exclude archived artists and artworks from `getArtist`, `getArtwork`, and listing helpers
- Add helper functions to archive or restore artists and artworks
- Rework gallery lookup to join artists and artworks with optional archived filters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891038c40d08320a62d71678d996d76