### PR TITLE
Filter archived records from gallery data

### DIFF
--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -64,8 +64,13 @@ function getGallery(slug, options, cb) {
           if (artwork.isFeatured) featured.push(artwork);
         }
       });
-      gallery.artists = Object.values(artistMap);
-      gallery.featuredArtworks = featured;
+      // Exclude archived artists and artworks from the returned gallery data
+      const artists = Object.values(artistMap).filter(a => !a.archived);
+      artists.forEach(a => {
+        a.artworks = a.artworks.filter(w => !w.archived);
+      });
+      gallery.artists = artists;
+      gallery.featuredArtworks = featured.filter(w => !w.archived);
       cb(null, gallery);
     });
   });

--- a/routes/public.js
+++ b/routes/public.js
@@ -2,6 +2,12 @@ const express = require('express');
 const router = express.Router();
 const { db } = require('../models/db');
 const { getGallery } = require('../models/galleryModel');
+
+// Default options to ensure archived artists and artworks are excluded
+const galleryOptions = {
+  includeArchivedArtists: false,
+  includeArchivedArtworks: false
+};
 const { getArtist } = require('../models/artistModel');
 const { getArtwork } = require('../models/artworkModel');
 
@@ -21,7 +27,7 @@ router.get('/faq', (req, res) => {
 // Public gallery home page
 router.get('/:gallerySlug', (req, res) => {
   try {
-    getGallery(req.params.gallerySlug, (err, gallery) => {
+    getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
       if (err) return res.status(404).send('Gallery not found');
       res.render('gallery-home', { gallery, slug: req.params.gallerySlug });
     });
@@ -34,7 +40,7 @@ router.get('/:gallerySlug', (req, res) => {
 // Artist profile page within a gallery
 router.get('/:gallerySlug/artists/:artistId', (req, res) => {
   try {
-    getGallery(req.params.gallerySlug, (err, gallery) => {
+    getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
       if (err) return res.status(404).send('Gallery not found');
       getArtist(req.params.gallerySlug, req.params.artistId, (err2, artist) => {
         if (err2) return res.status(404).send('Artist not found');
@@ -50,7 +56,7 @@ router.get('/:gallerySlug/artists/:artistId', (req, res) => {
 // Artwork detail page within a gallery
 router.get('/:gallerySlug/artworks/:artworkId', (req, res) => {
   try {
-    getGallery(req.params.gallerySlug, (err, gallery) => {
+    getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
       if (err) return res.status(404).send('Gallery not found');
       getArtwork(req.params.gallerySlug, req.params.artworkId, (err2, result) => {
         if (err2) return res.status(404).send('Artwork not found');


### PR DESCRIPTION
## Summary
- filter out archived artists and artworks when assembling gallery data
- ensure public routes invoke gallery model with options that exclude archived records

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689109a8a2848320a7359236a6c84361