### PR TITLE
feat: add live toggle for artists

### DIFF
--- a/migrations/004_add_artist_live.sql
+++ b/migrations/004_add_artist_live.sql
@@ -1,0 +1,2 @@
+-- Add live column to artists
+ALTER TABLE artists ADD COLUMN live INTEGER DEFAULT 0;

--- a/models/artistModel.js
+++ b/models/artistModel.js
@@ -2,7 +2,7 @@ const { db } = require('./db');
 
 function getArtist(gallerySlug, id, cb) {
   const artistSql =
-    'SELECT * FROM artists WHERE id = ? AND gallery_slug = ? AND archived = 0';
+    'SELECT * FROM artists WHERE id = ? AND gallery_slug = ? AND archived = 0 AND live = 1';
   db.get(artistSql, [id, gallerySlug], (err, artist) => {
     if (err || !artist) return cb(err || new Error('Not found'));
     const artSql = 'SELECT * FROM artworks WHERE artist_id = ? AND archived = 0';
@@ -14,9 +14,13 @@ function getArtist(gallerySlug, id, cb) {
   });
 }
 
-function createArtist(id, name, gallerySlug, cb) {
-  const stmt = `INSERT INTO artists (id, gallery_slug, name) VALUES (?,?,?)`;
-  db.run(stmt, [id, gallerySlug, name], cb);
+function createArtist(id, name, gallerySlug, live, cb) {
+  if (typeof live === 'function') {
+    cb = live;
+    live = 0;
+  }
+  const stmt = `INSERT INTO artists (id, gallery_slug, name, live) VALUES (?,?,?,?)`;
+  db.run(stmt, [id, gallerySlug, name, live ? 1 : 0], cb);
 }
 
 function getArtistById(id, cb) {

--- a/models/db.js
+++ b/models/db.js
@@ -32,7 +32,8 @@ function initialize() {
       bio_full TEXT,
       portrait_url TEXT,
       gallery_id TEXT,
-      archived INTEGER DEFAULT 0
+      archived INTEGER DEFAULT 0,
+      live INTEGER DEFAULT 0
     )`);
 
     db.run(`CREATE TABLE IF NOT EXISTS users (
@@ -154,7 +155,7 @@ function seed(done) {
   galleries.forEach(g => galleryStmt.run(g.slug, g.name, g.bio, g.contact_email, g.phone, g.logo_url));
   galleryStmt.finalize();
 
-  const artistStmt = db.prepare('INSERT INTO artists (id, gallery_slug, name, bio, bioImageUrl, fullBio) VALUES (?,?,?,?,?,?)');
+  const artistStmt = db.prepare('INSERT INTO artists (id, gallery_slug, name, bio, bioImageUrl, fullBio, live) VALUES (?,?,?,?,?,?,1)');
   artists.forEach(a => artistStmt.run(a.id, a.gallery_slug, a.name, a.bio, a.bioImageUrl, a.fullBio));
   artistStmt.finalize();
 

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -13,6 +13,7 @@ function getGallery(slug, options, cb) {
   db.get(galleryQuery, [slug], (err, gallery) => {
     if (err || !gallery) return cb(err || new Error('Not found'));
     const artistCond = includeArchivedArtists ? '' : 'AND a.archived = 0';
+    const liveCond = 'AND a.live = 1';
     const artworkCond = includeArchivedArtworks ? '' : 'AND w.archived = 0';
     const sql = `SELECT a.id as artistId, a.name as artistName, a.bio, a.bioImageUrl, a.fullBio, a.archived as artistArchived,
                         w.id as artworkId, w.title, w.medium, w.dimensions, w.price, w.imageFull, w.imageStandard, w.imageThumb,
@@ -20,7 +21,7 @@ function getGallery(slug, options, cb) {
                         w.archived as artworkArchived
                  FROM artists a
                  LEFT JOIN artworks w ON w.artist_id = a.id AND w.isVisible = 1 ${artworkCond}
-                 WHERE a.gallery_slug = ? ${artistCond}`;
+                 WHERE a.gallery_slug = ? ${artistCond} ${liveCond}`;
     db.all(sql, [slug], (err2, rows) => {
       if (err2) return cb(err2);
       const artistMap = {};

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -258,14 +258,14 @@ test('admin artist routes allow CRUD after login', async () => {
   const token = extractCsrfToken(page.body);
 
   const id = `testartist${Date.now()}`;
-  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id, gallery_slug: 'demo-gallery', name: 'Tester', bio: 'Bio', _csrf: token }, cookie);
+  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id, gallery_slug: 'demo-gallery', name: 'Tester', bio: 'Bio', live: 1, _csrf: token }, cookie);
   assert.strictEqual(res.statusCode, 302);
 
   res = await httpGet(`http://localhost:${port}/demo-gallery/artists/${id}`);
   assert.strictEqual(res.statusCode, 200);
   assert.match(res.body, /Tester/);
 
-  await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/${id}`, { name: 'Edited', bio: 'Bio' }, cookie, token);
+  await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/${id}`, { name: 'Edited', bio: 'Bio', live: 1 }, cookie, token);
   res = await httpGet(`http://localhost:${port}/demo-gallery/artists/${id}`);
   assert.match(res.body, /Edited/);
 
@@ -376,10 +376,10 @@ test('artist and artwork routes require login', async () => {
   const page = await httpGet(`http://localhost:${port}/login`);
   const token = extractCsrfToken(page.body);
   const cookie = page.headers['set-cookie'][0].split(';')[0];
-  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id: 'x', gallery_slug: 'demo-gallery', name: 'n', bio: 'b', _csrf: token }, cookie);
+  let res = await httpPostForm(`http://localhost:${port}/dashboard/artists`, { id: 'x', gallery_slug: 'demo-gallery', name: 'n', bio: 'b', live: 1, _csrf: token }, cookie);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
-  res = await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/x`, { name: 'n', bio: 'b' }, cookie, token);
+  res = await httpRequest('PUT', `http://localhost:${port}/dashboard/artists/x`, { name: 'n', bio: 'b', live: 1 }, cookie, token);
   assert.strictEqual(res.statusCode, 302);
   assert.strictEqual(res.headers.location, '/login');
   res = await httpRequest('DELETE', `http://localhost:${port}/dashboard/artists/x`, null, cookie, token);
@@ -401,7 +401,7 @@ test('artist artwork submission rejects invalid CSRF token', async () => {
   const port = server.address().port;
   const username = `artist${Date.now()}`;
   const userId = await new Promise(resolve => createUser('Artist', username, 'pass', 'artist', 'taos', (err, id) => resolve(id)));
-  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', () => resolve()));
+  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', 1, () => resolve()));
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -425,7 +425,7 @@ test('artist cannot access admin dashboard', async () => {
   const port = server.address().port;
   const username = `artist${Date.now()}x`;
   const userId = await new Promise(resolve => createUser('Artist2', username, 'pass', 'artist', 'taos', (err, id) => resolve(id)));
-  await new Promise(resolve => createArtist(userId, 'Artist2', 'demo-gallery', () => resolve()));
+  await new Promise(resolve => createArtist(userId, 'Artist2', 'demo-gallery', 1, () => resolve()));
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -442,7 +442,7 @@ test('artist artwork submission succeeds with valid CSRF token', async () => {
   const port = server.address().port;
   const username = `artist${Date.now()}`;
   const userId = await new Promise(resolve => createUser('Artist', username, 'pass', 'artist', 'taos', (err, id) => resolve(id)));
-  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', () => resolve()));
+  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', 1, () => resolve()));
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -665,7 +665,7 @@ test('archiving artist cascades to artworks', async () => {
 
   const artistId = 'test-artist-' + Date.now();
   await new Promise(resolve =>
-    db.run('INSERT INTO artists (id, gallery_slug, name) VALUES (?,?,?)', [artistId, 'demo-gallery', 'Temp'], resolve)
+    db.run('INSERT INTO artists (id, gallery_slug, name, live) VALUES (?,?,?,1)', [artistId, 'demo-gallery', 'Temp'], resolve)
   );
   const artworkId = 'test-artwork-' + Date.now();
   await new Promise(resolve =>
@@ -762,7 +762,7 @@ test('archiving artwork toggles public visibility', async () => {
 
   const artistId = 'test-artist-art-' + Date.now();
   await new Promise(resolve =>
-    db.run('INSERT INTO artists (id, gallery_slug, name) VALUES (?,?,?)', [artistId, 'demo-gallery', 'ArtArch'], resolve)
+    db.run('INSERT INTO artists (id, gallery_slug, name, live) VALUES (?,?,?,1)', [artistId, 'demo-gallery', 'ArtArch'], resolve)
   );
   const artworkId = 'test-only-artwork-' + Date.now();
   await new Promise(resolve =>

--- a/views/admin/artists.ejs
+++ b/views/admin/artists.ejs
@@ -23,12 +23,17 @@
       <ul id="artist-list" class="space-y-4">
         <% artists.forEach(function(a){ %>
           <li class="bg-white shadow-md rounded border">
-            <button class="artist-toggle w-full flex items-center p-4 text-left" data-id="<%= a.id %>">
+            <div class="artist-toggle w-full flex items-center p-4 cursor-pointer" data-id="<%= a.id %>">
               <span class="font-semibold flex-1"><%= a.name %></span>
-            </button>
+              <label class="flex items-center gap-2">
+                <span class="text-sm">Live</span>
+                <input type="checkbox" class="live-toggle" data-id="<%= a.id %>" <%= a.live ? 'checked' : '' %> />
+              </label>
+            </div>
             <div class="artist-form-wrapper max-h-0 opacity-0 overflow-hidden transition-all ease-in-out">
               <form class="p-4 space-y-2 artist-form" data-id="<%= a.id %>">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                <input type="hidden" name="live" value="<%= a.live ? 1 : 0 %>">
                 <label class="block text-sm font-medium">Name
                   <input name="name" value="<%= a.name %>" class="mt-1 w-full border rounded px-2 py-1"/>
                 </label>
@@ -59,12 +64,17 @@
       </ul>
       <template id="new-artist-template">
         <li class="bg-white shadow-md rounded border">
-          <button class="artist-toggle w-full flex items-center p-4 text-left" data-new="true">
+          <div class="artist-toggle w-full flex items-center p-4 cursor-pointer" data-new="true">
             <span class="font-semibold flex-1">New Artist</span>
-          </button>
+            <label class="flex items-center gap-2">
+              <span class="text-sm">Live</span>
+              <input type="checkbox" class="live-toggle" data-new="true" />
+            </label>
+          </div>
           <div class="artist-form-wrapper max-h-0 opacity-0 overflow-hidden transition-all ease-in-out">
             <form class="p-4 space-y-2 artist-form" data-new="true">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+              <input type="hidden" name="live" value="0">
               <label class="block text-sm font-medium">Gallery
                 <select name="gallery_slug" class="mt-1 w-full border rounded px-2 py-1">
                   <% galleries.forEach(function(g){ %>
@@ -115,9 +125,35 @@
         toggleWrapper(wrapper);
       });
     });
+
+    function initLiveToggle(toggle) {
+      toggle.addEventListener('click', e => e.stopPropagation());
+      toggle.addEventListener('change', async () => {
+        const form = toggle.closest('li').querySelector('form');
+        if (form) {
+          const hidden = form.querySelector('input[name="live"]');
+          if (hidden) hidden.value = toggle.checked ? '1' : '0';
+        }
+        if (toggle.dataset.new === 'true') return;
+        const id = toggle.dataset.id;
+        try {
+          const res = await fetch('/dashboard/artists/' + encodeURIComponent(id) + '/live', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken },
+            body: JSON.stringify({ live: toggle.checked })
+          });
+          if (!res.ok) throw new Error(await res.text() || res.statusText);
+        } catch (err) {
+          toggle.checked = !toggle.checked;
+        }
+      });
+    }
+    document.querySelectorAll('.live-toggle').forEach(initLiveToggle);
     function handleForm(form) {
       const btn = form.querySelector('.save-btn');
       let id = form.dataset.id;
+      const container = form.closest('li').querySelector('.artist-toggle');
+      const liveToggle = container.querySelector('.live-toggle');
       form.addEventListener('submit', async e => {
         e.preventDefault();
         const isNew = form.dataset.new === 'true';
@@ -134,9 +170,10 @@
             id = data.id;
             form.dataset.id = id;
             form.dataset.new = 'false';
-            const toggle = form.closest('li').querySelector('.artist-toggle');
-            toggle.dataset.id = id;
-            toggle.querySelector('span').textContent = formData.get('name') || id;
+            container.dataset.id = id;
+            container.querySelector('span').textContent = formData.get('name') || id;
+            liveToggle.dataset.id = id;
+            liveToggle.dataset.new = 'false';
             setTimeout(() => { btn.textContent = original; btn.disabled = false; }, 1000);
           } else {
             const dataObj = Object.fromEntries(new FormData(form).entries());
@@ -183,6 +220,8 @@
       const btn = li.querySelector('.artist-toggle');
       const wrapper = li.querySelector('.artist-form-wrapper');
       btn.addEventListener('click', () => toggleWrapper(wrapper));
+      const toggle = li.querySelector('.live-toggle');
+      initLiveToggle(toggle);
       handleForm(li.querySelector('form'));
       btn.click();
     });


### PR DESCRIPTION
## Summary
- allow galleries to mark artists as live via admin UI toggle
- persist and filter live artists with new database column
- update tests for artist visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68910b686e70832089b2a180ff64ad18