### PR TITLE
refactor: handle public route errors without try/catch

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -26,76 +26,79 @@ router.get('/faq', (req, res) => {
 
 // Public gallery home page
 router.get('/:gallerySlug', (req, res) => {
-  try {
-    getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
-      if (err) return res.status(404).send('Gallery not found');
-      res.render('gallery-home', { gallery, slug: req.params.gallerySlug });
-    });
-  } catch (err) {
-    console.error(err);
-    res.status(500).send('Server error');
-  }
+  getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
+    if (err) {
+      console.error(err);
+      return res.status(404).send('Gallery not found');
+    }
+    res.render('gallery-home', { gallery, slug: req.params.gallerySlug });
+  });
 });
 
 // Artist profile page within a gallery
 router.get('/:gallerySlug/artists/:artistId', (req, res) => {
-  try {
-    getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
-      if (err) return res.status(404).send('Gallery not found');
-      getArtist(req.params.gallerySlug, req.params.artistId, (err2, artist) => {
-        if (err2) return res.status(404).send('Artist not found');
-        res.render('artist-profile', { gallery, artist, slug: req.params.gallerySlug });
-      });
+  getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
+    if (err) {
+      console.error(err);
+      return res.status(404).send('Gallery not found');
+    }
+    getArtist(req.params.gallerySlug, req.params.artistId, (err2, artist) => {
+      if (err2) {
+        console.error(err2);
+        return res.status(404).send('Artist not found');
+      }
+      res.render('artist-profile', { gallery, artist, slug: req.params.gallerySlug });
     });
-  } catch (err) {
-    console.error(err);
-    res.status(500).send('Server error');
-  }
+  });
 });
 
 // Artwork detail page within a gallery
 router.get('/:gallerySlug/artworks/:artworkId', (req, res) => {
-  try {
-    getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
-      if (err) return res.status(404).send('Gallery not found');
-      getArtwork(req.params.gallerySlug, req.params.artworkId, (err2, result) => {
-        if (err2) return res.status(404).send('Artwork not found');
+  getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
+    if (err) {
+      console.error(err);
+      return res.status(404).send('Gallery not found');
+    }
+    getArtwork(req.params.gallerySlug, req.params.artworkId, (err2, result) => {
+      if (err2) {
+        console.error(err2);
+        return res.status(404).send('Artwork not found');
+      }
 
-        // Fetch full artist profile including other artworks
-        getArtist(req.params.gallerySlug, result.artistId, (err3, artist) => {
-          if (err3) return res.status(404).send('Artist not found');
+      // Fetch full artist profile including other artworks
+      getArtist(req.params.gallerySlug, result.artistId, (err3, artist) => {
+        if (err3) {
+          console.error(err3);
+          return res.status(404).send('Artist not found');
+        }
 
-          const moreFromArtist = (artist.artworks || []).filter(a => a.id !== result.artwork.id).slice(0, 5);
+        const moreFromArtist = (artist.artworks || []).filter(a => a.id !== result.artwork.id).slice(0, 5);
 
-          const relatedSql = `SELECT artworks.*, artists.name as artistName
+        const relatedSql = `SELECT artworks.*, artists.name as artistName
                                FROM artworks JOIN artists ON artworks.artist_id = artists.id
                                WHERE artworks.gallery_slug = ? AND artworks.artist_id != ? AND artworks.id != ?
                                LIMIT 8`;
-          db.all(relatedSql, [req.params.gallerySlug, result.artistId, result.artwork.id], (err4, relatedRows) => {
-            const relatedArtworks = err4 ? [] : relatedRows;
+        db.all(relatedSql, [req.params.gallerySlug, result.artistId, result.artwork.id], (err4, relatedRows) => {
+          const relatedArtworks = err4 ? [] : relatedRows;
 
-            res.render('artwork-detail', {
-              gallery,
-              artwork: result.artwork,
-              artist: {
-                id: artist.id,
-                name: artist.name,
-                bio: artist.bio,
-                bioImageUrl: artist.bioImageUrl
-              },
-              artistId: result.artistId,
-              slug: req.params.gallerySlug,
-              moreFromArtist,
-              relatedArtworks
-            });
+          res.render('artwork-detail', {
+            gallery,
+            artwork: result.artwork,
+            artist: {
+              id: artist.id,
+              name: artist.name,
+              bio: artist.bio,
+              bioImageUrl: artist.bioImageUrl
+            },
+            artistId: result.artistId,
+            slug: req.params.gallerySlug,
+            moreFromArtist,
+            relatedArtworks
           });
         });
       });
     });
-  } catch (err) {
-    console.error(err);
-    res.status(500).send('Server error');
-  }
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- remove ineffective try/catch blocks from public routes
- log errors and handle them within callbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689117a7aad88320831e6123e2422050