### PR TITLE
Require env-supplied admin credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ After running the server, visit `http://localhost:3000` in your browser to view 
 
 ### Configuration
 
-The server reads credentials and session configuration from environment variables. Most have development-friendly defaults, but `SESSION_SECRET` must always be provided:
+The server reads credentials and session configuration from environment variables. `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `SESSION_SECRET` must always be provided:
 
-- `ADMIN_USERNAME` – username for the admin login (defaults to `admin`)
-- `ADMIN_PASSWORD` – password for the admin login (defaults to `password`)
-- `SESSION_SECRET` – secret used to sign session cookies (required; set to a secure value)
+- `ADMIN_USERNAME` – username for the admin login
+- `ADMIN_PASSWORD` – password for the admin login
+- `SESSION_SECRET` – secret used to sign session cookies (set to a secure value)
 - `USE_DEMO_AUTH` – set to `true` to automatically log into admin pages
 
-Set these variables before starting the server. The application will refuse to start if `SESSION_SECRET` is not defined.
+Set these variables before starting the server. Use strong, unique values for the admin credentials. For production deployments, choose a username that is not easily guessable and a password of at least 12 characters that includes letters, numbers and symbols. The application will refuse to start if any required variables are missing.
 
 When `USE_DEMO_AUTH` is disabled (the default), all `/dashboard` routes require
 logging in. Set the variable to `true` during development to bypass the login

--- a/render.yaml
+++ b/render.yaml
@@ -9,9 +9,9 @@ services:
     runtime: node
     envVars:
       - key: ADMIN_USERNAME
-        value: admin
+        sync: false
       - key: ADMIN_PASSWORD
-        value: password
+        sync: false
       - key: SESSION_SECRET
         generateValue: true
       - key: USE_DEMO_AUTH

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -8,8 +8,12 @@ const { createGallery } = require('../models/galleryModel');
 const { db } = require('../models/db');
 const bcrypt = require('../utils/bcrypt');
 
-const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
-const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
+const ADMIN_USERNAME = process.env.ADMIN_USERNAME;
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+
+if (!ADMIN_USERNAME || !ADMIN_PASSWORD) {
+  throw new Error('ADMIN_USERNAME and ADMIN_PASSWORD environment variables must be set');
+}
 const VALID_PROMO_CODES = ['taos'];
 const USERNAME_REGEX = /^[a-z0-9-]+$/;
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,5 +1,7 @@
 process.env.USE_DEMO_AUTH = 'false';
 process.env.SESSION_SECRET = 'testsecret';
+process.env.ADMIN_USERNAME = 'admin';
+process.env.ADMIN_PASSWORD = 'password';
 const test = require('node:test');
 const assert = require('node:assert');
 const http = require('node:http');


### PR DESCRIPTION
## Summary
- require ADMIN_USERNAME and ADMIN_PASSWORD to be explicitly provided via environment variables
- document configuring strong admin credentials
- remove default admin credentials from Render blueprint and adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689117b1ac2883208e059d8bfdfcf188