### PR TITLE
Add dimensions field to artwork form

### DIFF
--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -24,6 +24,9 @@
                 <label class="block text-sm font-medium">Title
                   <input name="title" value="<%= art.title %>" class="mt-1 w-full border rounded px-2 py-1"/>
                 </label>
+                <label class="block text-sm font-medium">Dimensions
+                  <input name="dimensions" value="<%= art.dimensions %>" class="mt-1 w-full border rounded px-2 py-1"/>
+                </label>
                 <label class="block text-sm font-medium">Price
                   <input type="text" name="price" value="<%= art.price %>" class="mt-1 w-full border rounded px-2 py-1"/>
                 </label>
@@ -93,6 +96,9 @@
           </label>
           <label class="block text-sm font-medium">Title
             <input name="title" class="mt-1 w-full border rounded px-2 py-1"/>
+          </label>
+          <label class="block text-sm font-medium">Dimensions
+            <input name="dimensions" class="mt-1 w-full border rounded px-2 py-1"/>
           </label>
           <label class="block text-sm font-medium">Price
             <input type="text" name="price" class="mt-1 w-full border rounded px-2 py-1"/>


### PR DESCRIPTION
## Summary
- ensure artwork forms include required `dimensions` input so creation succeeds
- restore placeholder file for uploads directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68911b0574e88320b6cc5be1855a4feb