### PR TITLE
refactor: use shared slugify util

### DIFF
--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -5,6 +5,7 @@ const { requireRole } = require('../../middleware/auth');
 const csrf = require('csurf');
 const csrfProtection = csrf();
 const { processImages, uploadsDir } = require('../../utils/image');
+const { slugify } = require('../../utils/slug');
 const { createCollection, getCollectionsByArtist, updateCollection } = require('../../models/collectionModel');
 const { getArtworksByArtist, updateArtworkCollection, createArtwork } = require('../../models/artworkModel');
 const { getArtistById, updateArtist } = require('../../models/artistModel');
@@ -23,10 +24,6 @@ const upload = multer({
     fileSize: 10 * 1024 * 1024
   }
 });
-
-function slugify(str) {
-  return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-}
 
 router.get('/', requireRole('artist'), csrfProtection, (req, res) => {
   res.locals.csrfToken = req.csrfToken();

--- a/utils/slug.js
+++ b/utils/slug.js
@@ -44,4 +44,4 @@ function generateUniqueSlug(db, table, column, title) {
   });
 }
 
-module.exports = { generateUniqueSlug };
+module.exports = { slugify, generateUniqueSlug };


### PR DESCRIPTION
## Summary
- remove local slugify and import shared utility in artist dashboard routes
- export slugify helper from utils/slug

## Testing
- `npm test`
- `SESSION_SECRET=testsecret USE_DEMO_AUTH=false node /tmp/collection-test.js`

------
https://chatgpt.com/codex/tasks/task_e_68911c8bf7ac8320b8f1dddd843d3388