### PR TITLE
Refactor models to use Promises

### DIFF
--- a/models/artistModel.js
+++ b/models/artistModel.js
@@ -1,61 +1,84 @@
 const { db } = require('./db');
 
-function getArtist(gallerySlug, id, cb) {
-  const artistSql =
-    'SELECT * FROM artists WHERE id = ? AND gallery_slug = ? AND archived = 0 AND live = 1';
-  db.get(artistSql, [id, gallerySlug], (err, artist) => {
-    if (err || !artist) return cb(err || new Error('Not found'));
-    const artSql = 'SELECT * FROM artworks WHERE artist_id = ? AND archived = 0';
-    db.all(artSql, [id], (err2, artworks) => {
-      if (err2) return cb(err2);
-      artist.artworks = artworks || [];
-      cb(null, artist);
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
     });
   });
 }
 
-function createArtist(id, name, gallerySlug, live, cb) {
-  if (typeof live === 'function') {
-    cb = live;
-    live = 0;
-  }
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+async function getArtist(gallerySlug, id) {
+  const artistSql =
+    'SELECT * FROM artists WHERE id = ? AND gallery_slug = ? AND archived = 0 AND live = 1';
+  const artist = await get(artistSql, [id, gallerySlug]);
+  if (!artist) throw new Error('Not found');
+  const artworks = await all('SELECT * FROM artworks WHERE artist_id = ? AND archived = 0', [id]);
+  artist.artworks = artworks || [];
+  return artist;
+}
+
+async function createArtist(id, name, gallerySlug, live = 0) {
   const stmt = `INSERT INTO artists (id, gallery_slug, name, live, display_order)
                 VALUES (?,?,?,?, COALESCE((SELECT MAX(display_order) + 1 FROM artists WHERE gallery_slug = ?), 0))`;
-  db.run(stmt, [id, gallerySlug, name, live ? 1 : 0, gallerySlug], cb);
+  await run(stmt, [id, gallerySlug, name, live ? 1 : 0, gallerySlug]);
 }
 
-function getArtistById(id, cb) {
-  db.get('SELECT * FROM artists WHERE id = ?', [id], cb);
+async function getArtistById(id) {
+  return get('SELECT * FROM artists WHERE id = ?', [id]);
 }
 
-function updateArtist(id, name, bio, fullBio, bioImageUrl, cb) {
+async function updateArtist(id, name, bio, fullBio, bioImageUrl) {
   const stmt = `UPDATE artists SET name = ?, bio = ?, fullBio = ?, bioImageUrl = ? WHERE id = ?`;
-  db.run(stmt, [name, bio, fullBio, bioImageUrl, id], cb);
+  await run(stmt, [name, bio, fullBio, bioImageUrl, id]);
 }
 
-function archiveArtist(id, cb) {
-  db.serialize(() => {
-    db.run('BEGIN TRANSACTION');
-    const rollback = err => db.run('ROLLBACK', () => cb(err));
-    db.run('UPDATE artists SET archived = 1 WHERE id = ?', [id], err => {
-      if (err) return rollback(err);
-      db.run('UPDATE artworks SET archived = 1 WHERE artist_id = ?', [id], err2 => {
-        if (err2) return rollback(err2);
-        db.run('COMMIT', cb);
+async function archiveArtist(id) {
+  return new Promise((resolve, reject) => {
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      const rollback = err => db.run('ROLLBACK', () => reject(err));
+      db.run('UPDATE artists SET archived = 1 WHERE id = ?', [id], err => {
+        if (err) return rollback(err);
+        db.run('UPDATE artworks SET archived = 1 WHERE artist_id = ?', [id], err2 => {
+          if (err2) return rollback(err2);
+          db.run('COMMIT', err3 => (err3 ? reject(err3) : resolve()));
+        });
       });
     });
   });
 }
 
-function unarchiveArtist(id, cb) {
-  db.serialize(() => {
-    db.run('BEGIN TRANSACTION');
-    const rollback = err => db.run('ROLLBACK', () => cb(err));
-    db.run('UPDATE artists SET archived = 0 WHERE id = ?', [id], err => {
-      if (err) return rollback(err);
-      db.run('UPDATE artworks SET archived = 0 WHERE artist_id = ?', [id], err2 => {
-        if (err2) return rollback(err2);
-        db.run('COMMIT', cb);
+async function unarchiveArtist(id) {
+  return new Promise((resolve, reject) => {
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      const rollback = err => db.run('ROLLBACK', () => reject(err));
+      db.run('UPDATE artists SET archived = 0 WHERE id = ?', [id], err => {
+        if (err) return rollback(err);
+        db.run('UPDATE artworks SET archived = 0 WHERE artist_id = ?', [id], err2 => {
+          if (err2) return rollback(err2);
+          db.run('COMMIT', err3 => (err3 ? reject(err3) : resolve()));
+        });
       });
     });
   });

--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -1,77 +1,114 @@
 const { db } = require('./db');
 const { randomUUID } = require('crypto');
 
-function getArtwork(gallerySlug, id, cb) {
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+async function getArtwork(gallerySlug, id) {
   const query = `SELECT artworks.*, artists.gallery_slug, artists.id as artistId
                  FROM artworks JOIN artists ON artworks.artist_id = artists.id
                  WHERE artworks.id = ? AND artists.gallery_slug = ?
                  AND artworks.archived = 0 AND artists.archived = 0`;
-  db.get(query, [id, gallerySlug], (err, row) => {
-    if (err || !row) return cb(err || new Error('Not found'));
-    const artwork = {
-      id: row.id,
-      title: row.title,
-      medium: row.medium,
-      dimensions: row.dimensions,
-      price: row.price,
-      imageFull: row.imageFull,
-      imageStandard: row.imageStandard,
-      imageThumb: row.imageThumb,
-      status: row.status,
-      hide_collected: row.hide_collected,
-      featured: row.featured,
-      isVisible: row.isVisible,
-      isFeatured: row.isFeatured,
-      description: row.description,
-      framed: row.framed,
-      readyToHang: row.ready_to_hang
-    };
-    cb(null, { artwork, artistId: row.artistId });
-  });
+  const row = await get(query, [id, gallerySlug]);
+  if (!row) throw new Error('Not found');
+  const artwork = {
+    id: row.id,
+    title: row.title,
+    medium: row.medium,
+    dimensions: row.dimensions,
+    price: row.price,
+    imageFull: row.imageFull,
+    imageStandard: row.imageStandard,
+    imageThumb: row.imageThumb,
+    status: row.status,
+    hide_collected: row.hide_collected,
+    featured: row.featured,
+    isVisible: row.isVisible,
+    isFeatured: row.isFeatured,
+    description: row.description,
+    framed: row.framed,
+    readyToHang: row.ready_to_hang
+  };
+  return { artwork, artistId: row.artistId };
 }
 
-function getArtworksByArtist(artistId, cb) {
-  db.all('SELECT * FROM artworks WHERE artist_id = ? AND archived = 0', [artistId], cb);
+async function getArtworksByArtist(artistId) {
+  return all('SELECT * FROM artworks WHERE artist_id = ? AND archived = 0', [artistId]);
 }
 
-function updateArtworkCollection(id, collectionId, cb) {
-  db.run('UPDATE artworks SET collection_id = ? WHERE id = ?', [collectionId, id], cb);
+async function updateArtworkCollection(id, collectionId) {
+  await run('UPDATE artworks SET collection_id = ? WHERE id = ?', [collectionId, id]);
 }
 
-function createArtwork(artistId, title, medium, dimensions, price, description, framed, readyToHang, images, isFeatured, cb) {
-  db.get('SELECT gallery_slug FROM artists WHERE id = ?', [artistId], (err, row) => {
-    if (err || !row) return cb(err || new Error('Artist not found'));
-    const id = randomUUID();
-    const stmt = `INSERT INTO artworks (id, artist_id, gallery_slug, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured, description, framed, ready_to_hang)
+async function createArtwork(
+  artistId,
+  title,
+  medium,
+  dimensions,
+  price,
+  description,
+  framed,
+  readyToHang,
+  images,
+  isFeatured
+) {
+  const row = await get('SELECT gallery_slug FROM artists WHERE id = ?', [artistId]);
+  if (!row) throw new Error('Artist not found');
+  const id = randomUUID();
+  const stmt = `INSERT INTO artworks (id, artist_id, gallery_slug, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured, description, framed, ready_to_hang)
                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
-    const params = [
-      id,
-      artistId,
-      row.gallery_slug,
-      title,
-      medium,
-      dimensions,
-      price || '',
-      images.imageFull,
-      images.imageStandard,
-      images.imageThumb,
-      'available',
-      1,
-      isFeatured ? 1 : 0,
-      description || '',
-      framed ? 1 : 0,
-      readyToHang ? 1 : 0
-    ];
-    db.run(stmt, params, err2 => cb(err2, id));
-  });
+  const params = [
+    id,
+    artistId,
+    row.gallery_slug,
+    title,
+    medium,
+    dimensions,
+    price || '',
+    images.imageFull,
+    images.imageStandard,
+    images.imageThumb,
+    'available',
+    1,
+    isFeatured ? 1 : 0,
+    description || '',
+    framed ? 1 : 0,
+    readyToHang ? 1 : 0
+  ];
+  await run(stmt, params);
+  return id;
 }
 
-function archiveArtwork(id, cb) {
-  db.run('UPDATE artworks SET archived = 1 WHERE id = ?', [id], cb);
+async function archiveArtwork(id) {
+  await run('UPDATE artworks SET archived = 1 WHERE id = ?', [id]);
 }
 
-function unarchiveArtwork(id, cb) {
-  db.run('UPDATE artworks SET archived = 0 WHERE id = ?', [id], cb);
+async function unarchiveArtwork(id) {
+  await run('UPDATE artworks SET archived = 0 WHERE id = ?', [id]);
 }
 
 module.exports = {
@@ -82,3 +119,4 @@ module.exports = {
   archiveArtwork,
   unarchiveArtwork
 };
+

--- a/models/collectionModel.js
+++ b/models/collectionModel.js
@@ -1,16 +1,34 @@
 const { db } = require('./db');
 
-function createCollection(name, artistId, slug, cb) {
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+async function createCollection(name, artistId, slug) {
   const stmt = `INSERT INTO collections (name, artist_id, slug) VALUES (?,?,?)`;
-  db.run(stmt, [name, artistId, slug], cb);
+  await run(stmt, [name, artistId, slug]);
 }
 
-function getCollectionsByArtist(artistId, cb) {
-  db.all('SELECT * FROM collections WHERE artist_id = ?', [artistId], cb);
+async function getCollectionsByArtist(artistId) {
+  return all('SELECT * FROM collections WHERE artist_id = ?', [artistId]);
 }
 
-function updateCollection(id, name, cb) {
-  db.run('UPDATE collections SET name = ? WHERE id = ?', [name, id], cb);
+async function updateCollection(id, name) {
+  await run('UPDATE collections SET name = ? WHERE id = ?', [name, id]);
 }
 
 module.exports = { createCollection, getCollectionsByArtist, updateCollection };

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -1,86 +1,105 @@
 const { db } = require('./db');
 
-function getGallery(slug, options, cb) {
-  if (typeof options === 'function') {
-    cb = options;
-    options = {};
-  }
-  const { includeArchivedArtists = false, includeArchivedArtworks = false } =
-    options || {};
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+async function getGallery(slug, options = {}) {
+  const { includeArchivedArtists = false, includeArchivedArtworks = false } = options || {};
 
   const galleryQuery =
     'SELECT slug, name, bio, logo_url, contact_email, phone FROM galleries WHERE slug = ?';
-  db.get(galleryQuery, [slug], (err, gallery) => {
-    if (err || !gallery) return cb(err || new Error('Not found'));
-    const artistCond = includeArchivedArtists ? '' : 'AND a.archived = 0';
-    const liveCond = 'AND a.live = 1';
-    const artworkCond = includeArchivedArtworks ? '' : 'AND w.archived = 0';
-    const sql = `SELECT a.id as artistId, a.name as artistName, a.bio, a.bioImageUrl, a.fullBio, a.archived as artistArchived,
+  const gallery = await get(galleryQuery, [slug]);
+  if (!gallery) throw new Error('Not found');
+  const artistCond = includeArchivedArtists ? '' : 'AND a.archived = 0';
+  const liveCond = 'AND a.live = 1';
+  const artworkCond = includeArchivedArtworks ? '' : 'AND w.archived = 0';
+  const sql = `SELECT a.id as artistId, a.name as artistName, a.bio, a.bioImageUrl, a.fullBio, a.archived as artistArchived,
                         w.id as artworkId, w.title, w.medium, w.dimensions, w.price, w.imageFull, w.imageStandard, w.imageThumb,
                         w.status, w.hide_collected, w.featured, w.isVisible, w.isFeatured, w.description, w.framed, w.ready_to_hang,
                         w.archived as artworkArchived
                  FROM artists a
                  LEFT JOIN artworks w ON w.artist_id = a.id AND w.isVisible = 1 ${artworkCond}
                  WHERE a.gallery_slug = ? ${artistCond} ${liveCond}
-                 ORDER BY a.display_order`; 
-    db.all(sql, [slug], (err2, rows) => {
-      if (err2) return cb(err2);
-      const artistMap = {};
-      const featured = [];
-      rows.forEach(row => {
-        let artist = artistMap[row.artistId];
-        if (!artist) {
-          artist = {
-            id: row.artistId,
-            name: row.artistName,
-            bio: row.bio,
-            bioImageUrl: row.bioImageUrl,
-            fullBio: row.fullBio,
-            archived: row.artistArchived,
-            artworks: []
-          };
-          artistMap[row.artistId] = artist;
-        }
-        if (row.artworkId) {
-          const artwork = {
-            id: row.artworkId,
-            title: row.title,
-            medium: row.medium,
-            dimensions: row.dimensions,
-            price: row.price,
-            imageFull: row.imageFull,
-            imageStandard: row.imageStandard,
-            imageThumb: row.imageThumb,
-            status: row.status,
-            hide_collected: row.hide_collected,
-            featured: row.featured,
-            isVisible: row.isVisible,
-            isFeatured: row.isFeatured,
-            description: row.description,
-            framed: row.framed,
-            readyToHang: row.ready_to_hang,
-            archived: row.artworkArchived,
-            artistName: row.artistName
-          };
-          artist.artworks.push(artwork);
-          if (artwork.isFeatured) featured.push(artwork);
-        }
-      });
-      // Exclude archived artists and artworks from the returned gallery data
-      const artists = Object.values(artistMap).filter(a => !a.archived);
-      artists.forEach(a => {
-        a.artworks = a.artworks.filter(w => !w.archived);
-      });
-      gallery.artists = artists;
-      gallery.featuredArtworks = featured.filter(w => !w.archived);
-      cb(null, gallery);
-    });
+                 ORDER BY a.display_order`;
+  const rows = await all(sql, [slug]);
+  const artistMap = {};
+  const featured = [];
+  rows.forEach(row => {
+    let artist = artistMap[row.artistId];
+    if (!artist) {
+      artist = {
+        id: row.artistId,
+        name: row.artistName,
+        bio: row.bio,
+        bioImageUrl: row.bioImageUrl,
+        fullBio: row.fullBio,
+        archived: row.artistArchived,
+        artworks: []
+      };
+      artistMap[row.artistId] = artist;
+    }
+    if (row.artworkId) {
+      const artwork = {
+        id: row.artworkId,
+        title: row.title,
+        medium: row.medium,
+        dimensions: row.dimensions,
+        price: row.price,
+        imageFull: row.imageFull,
+        imageStandard: row.imageStandard,
+        imageThumb: row.imageThumb,
+        status: row.status,
+        hide_collected: row.hide_collected,
+        featured: row.featured,
+        isVisible: row.isVisible,
+        isFeatured: row.isFeatured,
+        description: row.description,
+        framed: row.framed,
+        readyToHang: row.ready_to_hang,
+        archived: row.artworkArchived,
+        artistName: row.artistName
+      };
+      artist.artworks.push(artwork);
+      if (artwork.isFeatured) featured.push(artwork);
+    }
   });
+  const artists = Object.values(artistMap).filter(a => !a.archived);
+  artists.forEach(a => {
+    a.artworks = a.artworks.filter(w => !w.archived);
+  });
+  gallery.artists = artists;
+  gallery.featuredArtworks = featured.filter(w => !w.archived);
+  return gallery;
 }
 
-function createGallery(slug, name, cb) {
+async function createGallery(slug, name) {
   const stmt = 'INSERT INTO galleries (slug, name) VALUES (?, ?)';
-  db.run(stmt, [slug, name], cb);
+  await run(stmt, [slug, name]);
 }
 
 module.exports = { getGallery, createGallery };
+

--- a/routes/dashboard/admin.js
+++ b/routes/dashboard/admin.js
@@ -430,15 +430,15 @@ router.delete('/artists/:id', requireRole('admin', 'gallery'), csrfProtection, (
 });
 
 router.patch('/artists/:id/archive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    archiveArtist(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+  const handle = async () => {
+    try {
+      await archiveArtist(req.params.id);
       req.flash('success', 'Artist archived');
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
     db.get('SELECT gallery_slug FROM artists WHERE id = ?', [req.params.id], (err, row) => {
@@ -453,15 +453,15 @@ router.patch('/artists/:id/archive', requireRole('admin', 'gallery'), csrfProtec
 });
 
 router.patch('/artists/:id/unarchive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    unarchiveArtist(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+  const handle = async () => {
+    try {
+      await unarchiveArtist(req.params.id);
       req.flash('success', 'Artist unarchived');
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
     db.get('SELECT gallery_slug FROM artists WHERE id = ?', [req.params.id], (err, row) => {
@@ -612,15 +612,15 @@ router.put('/artworks/:id', requireRole('admin', 'gallery'), upload.single('imag
 });
 
 router.patch('/artworks/:id/archive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    archiveArtwork(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+  const handle = async () => {
+    try {
+      await archiveArtwork(req.params.id);
       req.flash('success', 'Artwork archived');
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
     db.get('SELECT gallery_slug FROM artworks WHERE id=?', [req.params.id], (err, row) => {
@@ -635,15 +635,15 @@ router.patch('/artworks/:id/archive', requireRole('admin', 'gallery'), csrfProte
 });
 
 router.patch('/artworks/:id/unarchive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    unarchiveArtwork(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+  const handle = async () => {
+    try {
+      await unarchiveArtwork(req.params.id);
       req.flash('success', 'Artwork unarchived');
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
     db.get('SELECT gallery_slug FROM artworks WHERE id=?', [req.params.id], (err, row) => {

--- a/routes/public.js
+++ b/routes/public.js
@@ -25,80 +25,65 @@ router.get('/faq', (req, res) => {
 });
 
 // Public gallery home page
-router.get('/:gallerySlug', (req, res) => {
-  getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
-    if (err) {
-      console.error(err);
-      return res.status(404).send('Gallery not found');
-    }
+router.get('/:gallerySlug', async (req, res) => {
+  try {
+    const gallery = await getGallery(req.params.gallerySlug, galleryOptions);
     res.render('gallery-home', { gallery, slug: req.params.gallerySlug });
-  });
+  } catch (err) {
+    console.error(err);
+    res.status(404).send('Gallery not found');
+  }
 });
 
 // Artist profile page within a gallery
-router.get('/:gallerySlug/artists/:artistId', (req, res) => {
-  getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
-    if (err) {
-      console.error(err);
-      return res.status(404).send('Gallery not found');
-    }
-    getArtist(req.params.gallerySlug, req.params.artistId, (err2, artist) => {
-      if (err2) {
-        console.error(err2);
-        return res.status(404).send('Artist not found');
-      }
-      res.render('artist-profile', { gallery, artist, slug: req.params.gallerySlug });
-    });
-  });
+router.get('/:gallerySlug/artists/:artistId', async (req, res) => {
+  try {
+    const gallery = await getGallery(req.params.gallerySlug, galleryOptions);
+    const artist = await getArtist(req.params.gallerySlug, req.params.artistId);
+    res.render('artist-profile', { gallery, artist, slug: req.params.gallerySlug });
+  } catch (err) {
+    console.error(err);
+    res.status(404).send('Artist not found');
+  }
 });
 
 // Artwork detail page within a gallery
-router.get('/:gallerySlug/artworks/:artworkId', (req, res) => {
-  getGallery(req.params.gallerySlug, galleryOptions, (err, gallery) => {
-    if (err) {
-      console.error(err);
-      return res.status(404).send('Gallery not found');
-    }
-    getArtwork(req.params.gallerySlug, req.params.artworkId, (err2, result) => {
-      if (err2) {
-        console.error(err2);
-        return res.status(404).send('Artwork not found');
-      }
+router.get('/:gallerySlug/artworks/:artworkId', async (req, res) => {
+  try {
+    const gallery = await getGallery(req.params.gallerySlug, galleryOptions);
+    const result = await getArtwork(req.params.gallerySlug, req.params.artworkId);
+    const artist = await getArtist(req.params.gallerySlug, result.artistId);
+    const moreFromArtist = (artist.artworks || []).filter(a => a.id !== result.artwork.id).slice(0, 5);
 
-      // Fetch full artist profile including other artworks
-      getArtist(req.params.gallerySlug, result.artistId, (err3, artist) => {
-        if (err3) {
-          console.error(err3);
-          return res.status(404).send('Artist not found');
-        }
-
-        const moreFromArtist = (artist.artworks || []).filter(a => a.id !== result.artwork.id).slice(0, 5);
-
-        const relatedSql = `SELECT artworks.*, artists.name as artistName
+    const relatedSql = `SELECT artworks.*, artists.name as artistName
                                FROM artworks JOIN artists ON artworks.artist_id = artists.id
                                WHERE artworks.gallery_slug = ? AND artworks.artist_id != ? AND artworks.id != ?
                                LIMIT 8`;
-        db.all(relatedSql, [req.params.gallerySlug, result.artistId, result.artwork.id], (err4, relatedRows) => {
-          const relatedArtworks = err4 ? [] : relatedRows;
-
-          res.render('artwork-detail', {
-            gallery,
-            artwork: result.artwork,
-            artist: {
-              id: artist.id,
-              name: artist.name,
-              bio: artist.bio,
-              bioImageUrl: artist.bioImageUrl
-            },
-            artistId: result.artistId,
-            slug: req.params.gallerySlug,
-            moreFromArtist,
-            relatedArtworks
-          });
-        });
+    const relatedArtworks = await new Promise((resolve, reject) => {
+      db.all(relatedSql, [req.params.gallerySlug, result.artistId, result.artwork.id], (err4, rows) => {
+        if (err4) return reject(err4);
+        resolve(rows);
       });
     });
-  });
+
+    res.render('artwork-detail', {
+      gallery,
+      artwork: result.artwork,
+      artist: {
+        id: artist.id,
+        name: artist.name,
+        bio: artist.bio,
+        bioImageUrl: artist.bioImageUrl
+      },
+      artistId: result.artistId,
+      slug: req.params.gallerySlug,
+      moreFromArtist,
+      relatedArtworks
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(404).send('Artwork not found');
+  }
 });
 
 module.exports = router;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -219,7 +219,7 @@ test('logout destroys session', async () => {
 test('non-admin users cannot access admin routes', async () => {
   const port = server.address().port;
   const username = `artist${randomUUID()}`;
-  await new Promise(resolve => createUser('Artist', username, 'pass', 'artist', 'taos', () => resolve()));
+  await createUser('Artist', username, 'pass', 'artist', 'taos');
   const stored = await new Promise(resolve => {
     db.get('SELECT password FROM users WHERE username=?', [username], (err, row) => resolve(row));
   });
@@ -401,8 +401,8 @@ test('artist and artwork routes require login', async () => {
 test('artist artwork submission rejects invalid CSRF token', async () => {
   const port = server.address().port;
   const username = `artist${randomUUID()}`;
-  const userId = await new Promise(resolve => createUser('Artist', username, 'pass', 'artist', 'taos', (err, id) => resolve(id)));
-  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', 1, () => resolve()));
+  const userId = await createUser('Artist', username, 'pass', 'artist', 'taos');
+  await createArtist(userId, 'Artist', 'demo-gallery', 1);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -425,8 +425,8 @@ test('artist artwork submission rejects invalid CSRF token', async () => {
 test('artist cannot access admin dashboard', async () => {
   const port = server.address().port;
   const username = `artist${randomUUID()}x`;
-  const userId = await new Promise(resolve => createUser('Artist2', username, 'pass', 'artist', 'taos', (err, id) => resolve(id)));
-  await new Promise(resolve => createArtist(userId, 'Artist2', 'demo-gallery', 1, () => resolve()));
+  const userId = await createUser('Artist2', username, 'pass', 'artist', 'taos');
+  await createArtist(userId, 'Artist2', 'demo-gallery', 1);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -442,8 +442,8 @@ test('artist cannot access admin dashboard', async () => {
 test('artist artwork submission succeeds with valid CSRF token', async () => {
   const port = server.address().port;
   const username = `artist${randomUUID()}`;
-  const userId = await new Promise(resolve => createUser('Artist', username, 'pass', 'artist', 'taos', (err, id) => resolve(id)));
-  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', 1, () => resolve()));
+  const userId = await createUser('Artist', username, 'pass', 'artist', 'taos');
+  await createArtist(userId, 'Artist', 'demo-gallery', 1);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];


### PR DESCRIPTION
## Summary
- refactor all database models to return Promises and use async/await instead of callbacks
- update routes to await model calls and handle errors with try/catch; adjust tests for new async APIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911c95667483209e8d7f9113929227