### PR TITLE
Refactor public routes to async

### DIFF
--- a/middleware/notFound.js
+++ b/middleware/notFound.js
@@ -1,0 +1,8 @@
+function send404(res, message, err) {
+  if (err) {
+    console.error(err);
+  }
+  res.status(404).send(message);
+}
+
+module.exports = send404;


### PR DESCRIPTION
## Summary
- refactor public gallery routes to async/await with util.promisify
- consolidate repeated 404 handling into shared helper
- fetch related artworks using promise-based db calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68911cb15da88320b530645ea6185f4e