### PR TITLE
refactor: centralize multer upload config

### DIFF
--- a/middleware/upload.js
+++ b/middleware/upload.js
@@ -1,0 +1,21 @@
+const multer = require('multer');
+const { uploadsDir } = require('../utils/image');
+
+const fileFilter = (req, file, cb) => {
+  const allowed = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
+  if (allowed.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new Error('Only JPG, PNG, or HEIC images are allowed'));
+  }
+};
+
+const upload = multer({
+  dest: uploadsDir,
+  fileFilter,
+  limits: {
+    fileSize: 10 * 1024 * 1024 // 10MB
+  }
+});
+
+module.exports = upload;

--- a/routes/dashboard/admin.js
+++ b/routes/dashboard/admin.js
@@ -1,32 +1,17 @@
 const express = require('express');
 const router = express.Router();
 const fs = require('fs');
-const multer = require('multer');
 const randomAvatar = require('../../utils/avatar');
 const { requireRole } = require('../../middleware/auth');
 const { generateUniqueSlug } = require('../../utils/slug');
 const { processImages, uploadsDir } = require('../../utils/image');
+const upload = require('../../middleware/upload');
 const csrf = require('csurf');
 const csrfProtection = csrf();
 
 const { db } = require('../../models/db');
 const { archiveArtist, unarchiveArtist } = require('../../models/artistModel');
 const { archiveArtwork, unarchiveArtwork } = require('../../models/artworkModel');
-
-const upload = multer({
-  dest: uploadsDir,
-  fileFilter: (req, file, cb) => {
-    const allowed = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
-    if (allowed.includes(file.mimetype)) {
-      cb(null, true);
-    } else {
-      cb(new Error('Only JPG, PNG, or HEIC images are allowed'));
-    }
-  },
-  limits: {
-    fileSize: 10 * 1024 * 1024 // 10MB
-  }
-});
 
 // Gallery dashboard for gallery role
 router.get('/gallery', requireRole('gallery'), (req, res) => {

--- a/routes/dashboard/artist.js
+++ b/routes/dashboard/artist.js
@@ -1,28 +1,13 @@
 const express = require('express');
 const router = express.Router();
-const multer = require('multer');
 const { requireRole } = require('../../middleware/auth');
 const csrf = require('csurf');
 const csrfProtection = csrf();
-const { processImages, uploadsDir } = require('../../utils/image');
+const { processImages } = require('../../utils/image');
+const upload = require('../../middleware/upload');
 const { createCollection, getCollectionsByArtist, updateCollection } = require('../../models/collectionModel');
 const { getArtworksByArtist, updateArtworkCollection, createArtwork } = require('../../models/artworkModel');
 const { getArtistById, updateArtist } = require('../../models/artistModel');
-
-const upload = multer({
-  dest: uploadsDir,
-  fileFilter: (req, file, cb) => {
-    const allowed = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
-    if (allowed.includes(file.mimetype)) {
-      cb(null, true);
-    } else {
-      cb(new Error('Only JPG, PNG, or HEIC images are allowed'));
-    }
-  },
-  limits: {
-    fileSize: 10 * 1024 * 1024
-  }
-});
 
 function slugify(str) {
   return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const upload = require('../middleware/upload');
+
+test('upload middleware uses 10MB limit', () => {
+  assert.strictEqual(upload.limits.fileSize, 10 * 1024 * 1024);
+});
+
+test('upload middleware filters file types', async () => {
+  await new Promise(resolve => {
+    upload.fileFilter({}, { mimetype: 'image/jpeg' }, err => {
+      assert.ifError(err);
+      resolve();
+    });
+  });
+  await new Promise(resolve => {
+    upload.fileFilter({}, { mimetype: 'text/plain' }, err => {
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Only JPG, PNG, or HEIC images are allowed');
+      resolve();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared multer upload middleware with common file filters and size limits
- refactor admin and artist dashboard routes to use centralized upload middleware
- test middleware to ensure file size and type constraints are enforced

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68911cc9d8e08320bb0c6bfd86881299