### PR TITLE
refactor: extract flash fallback middleware

### DIFF
--- a/middleware/flashFallback.js
+++ b/middleware/flashFallback.js
@@ -1,0 +1,38 @@
+module.exports = function flashFallback() {
+  let connectFlash;
+  try {
+    connectFlash = require('connect-flash');
+  } catch (err) {
+    connectFlash = null;
+  }
+
+  if (connectFlash) {
+    return connectFlash();
+  }
+
+  return (req, res, next) => {
+    if (!req.session) throw new Error('flash requires sessions');
+    const flash = req.session.flash || {};
+
+    req.flash = function (type, msg) {
+      if (type && msg) {
+        flash[type] = flash[type] || [];
+        flash[type].push(msg);
+        req.session.flash = flash;
+        return flash[type];
+      }
+
+      if (type) {
+        const msgs = flash[type] || [];
+        delete flash[type];
+        req.session.flash = flash;
+        return msgs;
+      }
+
+      req.session.flash = {};
+      return flash;
+    };
+
+    next();
+  };
+};

--- a/server.js
+++ b/server.js
@@ -8,36 +8,7 @@ try {
 }
 const bodyParser = require('body-parser');
 const path = require('path');
-let flash;
-try {
-  flash = require('connect-flash');
-} catch (err) {
-  // Fallback implementation when connect-flash is not installed
-  flash = () => (req, res, next) => {
-    req.flash = function(type, msg) {
-      if (!req.session) throw new Error('flash requires sessions');
-      const flash = req.session.flash || {};
-
-      if (type && msg) {
-        flash[type] = flash[type] || [];
-        flash[type].push(msg);
-        req.session.flash = flash;
-        return flash[type];
-      }
-
-      if (type) {
-        const msgs = flash[type] || [];
-        delete flash[type];
-        req.session.flash = flash;
-        return msgs;
-      }
-
-      req.session.flash = {};
-      return flash;
-    };
-    next();
-  };
-}
+const flash = require('./middleware/flashFallback');
 require('./models/db');
 
 function simulateAuth(req, res, next) {


### PR DESCRIPTION
## Summary
- move flash fallback to middleware/flashFallback.js
- use flashFallback middleware in server.js

## Testing
- `npm test`
- manual flash middleware test without connect-flash

------
https://chatgpt.com/codex/tasks/task_e_68911cd483ec832094f2830e417c8858