### PR TITLE
Clean up legacy featured field

### DIFF
--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -19,7 +19,6 @@ function getArtwork(gallerySlug, id, cb) {
       imageThumb: row.imageThumb,
       status: row.status,
       hide_collected: row.hide_collected,
-      featured: row.featured,
       isVisible: row.isVisible,
       isFeatured: row.isFeatured,
       description: row.description,

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -17,7 +17,7 @@ function getGallery(slug, options, cb) {
     const artworkCond = includeArchivedArtworks ? '' : 'AND w.archived = 0';
     const sql = `SELECT a.id as artistId, a.name as artistName, a.bio, a.bioImageUrl, a.fullBio, a.archived as artistArchived,
                         w.id as artworkId, w.title, w.medium, w.dimensions, w.price, w.imageFull, w.imageStandard, w.imageThumb,
-                        w.status, w.hide_collected, w.featured, w.isVisible, w.isFeatured, w.description, w.framed, w.ready_to_hang,
+                        w.status, w.hide_collected, w.isVisible, w.isFeatured, w.description, w.framed, w.ready_to_hang,
                         w.archived as artworkArchived
                  FROM artists a
                  LEFT JOIN artworks w ON w.artist_id = a.id AND w.isVisible = 1 ${artworkCond}
@@ -53,7 +53,6 @@ function getGallery(slug, options, cb) {
             imageThumb: row.imageThumb,
             status: row.status,
             hide_collected: row.hide_collected,
-            featured: row.featured,
             isVisible: row.isVisible,
             isFeatured: row.isFeatured,
             description: row.description,


### PR DESCRIPTION
## Summary
- drop unused `featured` field from artwork retrieval
- rely solely on `isFeatured` across gallery and artwork models

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689122eb089c83208cefee4bd41b3c17