### PR TITLE
Show detailed errors when saving artworks

### DIFF
--- a/server.js
+++ b/server.js
@@ -95,7 +95,8 @@ app.use((err, req, res, next) => {
     return res.status(403).render('403');
   }
   console.error(err);
-  res.status(500).send('Server error');
+  const status = err.status || err.statusCode || 500;
+  res.status(status).send(err.message || 'Server error');
 });
 
 const PORT = process.env.PORT || 3000;

--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -210,6 +210,8 @@
             }
           }, 1000);
         } catch(err) {
+          const message = err.message || 'Error saving artwork';
+          alert(message);
           btn.textContent = 'Error';
           setTimeout(() => { btn.textContent = original; btn.disabled = false; }, 2000);
         }


### PR DESCRIPTION
## Summary
- Display server-provided error messages when artwork save fails so users know what went wrong
- Return specific error text from global error handler instead of a generic response

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923ba0e4f48320bcbb064ac1979ee8