### PR TITLE
Allow artists to manage their own artworks

### DIFF
--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -87,6 +87,7 @@
       <div class="art-form-wrapper max-h-0 opacity-0 overflow-hidden transition-all ease-in-out">
         <form class="p-4 space-y-2 art-form" data-new="true" enctype="multipart/form-data">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <% if (user.role !== 'artist') { %>
           <label class="block text-sm font-medium">Artist
             <select name="artist_id" class="mt-1 w-full border rounded px-2 py-1 artist-select">
               <% artists.forEach(function(a){ %>
@@ -94,6 +95,7 @@
               <% }) %>
             </select>
           </label>
+          <% } %>
           <label class="block text-sm font-medium">Title
             <input name="title" class="mt-1 w-full border rounded px-2 py-1"/>
           </label>


### PR DESCRIPTION
## Summary
- Let artists access artwork dashboard and upload routes
- Default new artworks to the logged in artist and limit collections/artist lists accordingly
- Hide artist selection for artists in dashboard and extend tests for artist uploads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924ab1514c83209c45b9a16ee5fce5