### PR TITLE
Add Docker support and configurable DB location

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+gallery.db
+sessions.db
+*.sqlite
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use Node.js 20 LTS image
+FROM node:20
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Bundle app source
+COPY . .
+
+# Build CSS assets
+RUN npm run build:css
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The server reads credentials and session configuration from environment variable
 - `ADMIN_USERNAME` – username for the admin login (defaults to `admin`)
 - `ADMIN_PASSWORD` – password for the admin login (defaults to `password`)
 - `SESSION_SECRET` – secret used to sign session cookies (required; set to a secure value)
+- `DB_FILE` – optional path to the SQLite database file (defaults to `gallery.db`)
 - `USE_DEMO_AUTH` – set to `true` to automatically log into admin pages
 
 Set these variables before starting the server. The application will refuse to start if `SESSION_SECRET` is not defined.
@@ -43,6 +44,26 @@ Running `npm install` will install this dependency and the application will
 create a `sessions.db` file in the project root to store session data. Session
 cookies are configured with the `secure` flag when `NODE_ENV` is set to
 `production` and always use the `httpOnly` flag for improved security.
+
+## Running with Docker
+
+To build and start the application in a container:
+
+```bash
+docker build -t fineartsuite .
+docker run -p 3000:3000 -e SESSION_SECRET=changeme fineartsuite
+```
+
+The container stores data in a SQLite file. To persist it outside the container
+mount a volume and point `DB_FILE` at the mounted path:
+
+```bash
+docker run -p 3000:3000 \
+  -e SESSION_SECRET=changeme \
+  -v $(pwd)/data:/app/data \
+  -e DB_FILE=/app/data/gallery.db \
+  fineartsuite
+```
 
 ## Gallery pages
 

--- a/models/db.js
+++ b/models/db.js
@@ -4,7 +4,8 @@ const fs = require('fs');
 const bcrypt = require('../utils/bcrypt');
 const randomAvatar = require('../utils/avatar');
 
-const db = new sqlite3.Database(path.join(__dirname, '..', 'gallery.db'));
+const dbFile = process.env.DB_FILE || path.join(__dirname, '..', 'gallery.db');
+const db = new sqlite3.Database(dbFile);
 
 function initialize() {
   db.serialize(() => {


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore to build and run the app in a container
- allow SQLite path override via `DB_FILE` env variable
- document Docker usage and new environment variable in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892aed2537c832099a82844c7693069