### PR TITLE
feat: add onboarding wizard and shared flow utilities

### DIFF
--- a/client/components/OnboardingWizard.jsx
+++ b/client/components/OnboardingWizard.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getStepsForRole, getRoleLabel, toTitleCase } from '../userFlow';
+
+export default function OnboardingWizard({ role, initialStep }) {
+  const steps = getStepsForRole(role);
+  const navigate = useNavigate();
+  const initialIndex = Math.max(0, steps.findIndex(s => s.step === initialStep));
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+
+  useEffect(() => {
+    const idx = steps.findIndex(s => s.step === initialStep);
+    if (idx >= 0) setCurrentIndex(idx);
+  }, [initialStep, steps]);
+
+  const current = steps[currentIndex] || { step: '', actions: [] };
+
+  const handleNext = () => {
+    const nextIndex = currentIndex + 1;
+    if (nextIndex < steps.length) {
+      const nextStep = steps[nextIndex].step;
+      navigate(`/onboarding/${role}/${nextStep}`);
+      setCurrentIndex(nextIndex);
+    }
+  };
+
+  return (
+    <div>
+      <h1>{getRoleLabel(role)} Onboarding</h1>
+      <ol>
+        {steps.map((s, idx) => (
+          <li key={s.step} style={{ fontWeight: idx === currentIndex ? 'bold' : 'normal' }}>
+            {toTitleCase(s.step)}
+            {idx < currentIndex ? ' ✓' : ''}
+          </li>
+        ))}
+      </ol>
+      <h2>{toTitleCase(current.step)}</h2>
+      <ul>
+        {current.actions.map(action => (
+          <li key={action}>{toTitleCase(action)}</li>
+        ))}
+      </ul>
+      {currentIndex < steps.length - 1 && (
+        <button onClick={handleNext}>Next</button>
+      )}
+    </div>
+  );
+}

--- a/client/routes/onboardingRoutes.jsx
+++ b/client/routes/onboardingRoutes.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Routes, Route, useParams } from 'react-router-dom';
+import OnboardingWizard from '../components/OnboardingWizard.jsx';
+
+function OnboardingRouteWrapper() {
+  const { role, step } = useParams();
+  return <OnboardingWizard role={role} initialStep={step} />;
+}
+
+export default function OnboardingRoutes() {
+  return (
+    <Routes>
+      <Route path="/onboarding/:role/:step" element={<OnboardingRouteWrapper />} />
+    </Routes>
+  );
+}

--- a/client/userFlow.js
+++ b/client/userFlow.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const flowPath = path.join(__dirname, '..', 'user_flow.json');
+const flowData = JSON.parse(fs.readFileSync(flowPath, 'utf-8'));
+
+function getStepsForRole(role) {
+  return flowData.roles[role]?.steps || [];
+}
+
+function getRoleLabel(role) {
+  return flowData.roles[role]?.label || '';
+}
+
+function getNextStep(role, currentStep) {
+  const steps = getStepsForRole(role);
+  const index = steps.findIndex(s => s.step === currentStep);
+  if (index === -1 || index + 1 >= steps.length) return null;
+  return steps[index + 1].step;
+}
+
+function getSharedFeatures() {
+  return flowData.shared_features || [];
+}
+
+function toTitleCase(str) {
+  return str
+    .split('_')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+module.exports = {
+  flowData,
+  getStepsForRole,
+  getRoleLabel,
+  getNextStep,
+  getSharedFeatures,
+  toTitleCase
+};

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { getStepsForRole, getNextStep, getSharedFeatures } = require('../client/userFlow');
+
+test('gallery owner navigation order', () => {
+  const steps = getStepsForRole('gallery_owner');
+  assert.strictEqual(steps[0].step, 'signup');
+  assert.strictEqual(getNextStep('gallery_owner', 'signup'), 'initial_setup');
+  assert.strictEqual(getNextStep('gallery_owner', 'initial_setup'), 'add_artists');
+});
+
+test('artist navigation reaches end', () => {
+  assert.strictEqual(getNextStep('artist', 'track_activity'), null);
+});
+
+test('shared features include messaging', () => {
+  const features = getSharedFeatures();
+  assert.ok(Array.isArray(features));
+  assert.ok(features.includes('messaging'));
+});

--- a/user_flow.json
+++ b/user_flow.json
@@ -1,0 +1,156 @@
+{
+  "roles": {
+    "gallery_owner": {
+      "label": "Gallery Owner",
+      "steps": [
+        {
+          "step": "signup",
+          "actions": [
+            "visit_landing_page",
+            "select_role_gallery_owner",
+            "enter_email_password",
+            "verify_email"
+          ]
+        },
+        {
+          "step": "initial_setup",
+          "actions": [
+            "upload_logo",
+            "add_gallery_bio",
+            "set_location",
+            "add_contact_info",
+            "connect_social_links",
+            "select_template",
+            "set_language_currency",
+            "connect_domain_optional"
+          ]
+        },
+        {
+          "step": "add_artists",
+          "actions": [
+            "invite_artist_by_email",
+            "create_artist_profile",
+            "upload_artist_bio",
+            "assign_artist_to_collection"
+          ]
+        },
+        {
+          "step": "add_artworks",
+          "actions": [
+            "upload_artwork",
+            "enter_artwork_details",
+            "set_pricing_and_status",
+            "organize_by_collection"
+          ]
+        },
+        {
+          "step": "setup_exhibition",
+          "actions": [
+            "create_exhibition",
+            "assign_artworks_and_artists",
+            "set_viewing_status",
+            "schedule_announcement"
+          ]
+        },
+        {
+          "step": "customize_website",
+          "actions": [
+            "choose_homepage_layout",
+            "add_sections",
+            "configure_carousel_or_grid"
+          ]
+        },
+        {
+          "step": "activate_sales",
+          "actions": [
+            "enable_sales",
+            "set_shipping_options",
+            "connect_payment_gateway",
+            "configure_tax",
+            "upload_certificate_template"
+          ]
+        },
+        {
+          "step": "publish_site",
+          "actions": [
+            "preview_site",
+            "go_live"
+          ]
+        },
+        {
+          "step": "manage_site",
+          "actions": [
+            "update_inventory",
+            "post_news",
+            "view_analytics",
+            "track_sales",
+            "use_crm"
+          ]
+        }
+      ]
+    },
+    "artist": {
+      "label": "Artist",
+      "steps": [
+        {
+          "step": "signup",
+          "actions": [
+            "visit_landing_page",
+            "select_role_artist",
+            "enter_email_password",
+            "verify_email"
+          ]
+        },
+        {
+          "step": "initial_setup",
+          "actions": [
+            "upload_headshot",
+            "fill_bio_and_statement",
+            "connect_social_links",
+            "upload_cv",
+            "choose_theme"
+          ]
+        },
+        {
+          "step": "upload_artworks",
+          "actions": [
+            "upload_artwork_files",
+            "enter_details",
+            "set_price_edition_status"
+          ]
+        },
+        {
+          "step": "accept_gallery_invite",
+          "actions": [
+            "review_invite",
+            "accept_terms",
+            "share_selected_works"
+          ]
+        },
+        {
+          "step": "artist_page",
+          "actions": [
+            "enable_personal_page",
+            "customize_layout",
+            "share_public_link"
+          ]
+        },
+        {
+          "step": "track_activity",
+          "actions": [
+            "view_sales",
+            "download_invoices",
+            "update_profile"
+          ]
+        }
+      ]
+    }
+  },
+  "shared_features": [
+    "messaging",
+    "artwork_status_sync",
+    "activity_feed",
+    "email_alerts",
+    "analytics_dashboard"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `user_flow.json` describing onboarding steps for gallery owners and artists
- create utilities to parse onboarding flow and compute next steps
- implement React-based `OnboardingWizard` with dynamic steps and progress
- expose routes for `/onboarding/:role/:step`
- cover navigation logic with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893da1ee2c88320bd5f55b8914db0a5