### PR TITLE
Extract navigation header partial

### DIFF
--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -7,12 +7,7 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="font-sans bg-white text-black">
-  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex gap-4 mt-2 md:mt-0">
-      <a href="/<%= slug %>" class="hover:underline">Gallery</a>
-    </div>
-  </nav>
+  <%- include('partials/header', { gallery, slug }) %>
 
   <main class="max-w-4xl mx-auto p-6">
     <header class="text-center mb-12">

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -11,12 +11,7 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="font-sans bg-white text-black">
-  <nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
-    <a href="/" class="text-2xl font-bold">FineArtSuite</a>
-    <div class="flex gap-4 mt-2 md:mt-0">
-      <a href="/" class="hover:underline">Home</a>
-    </div>
-  </nav>
+  <%- include('partials/header', { gallery, slug }) %>
 
   <main class="max-w-4xl mx-auto p-6">
     <header class="text-center mb-12">

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,0 +1,10 @@
+<nav class="flex flex-col items-center justify-between p-4 border-b border-gray-300 md:flex-row">
+  <a href="/" class="text-2xl font-bold">FineArtSuite</a>
+  <div class="flex gap-4 mt-2 md:mt-0">
+    <% if (typeof artist !== 'undefined') { %>
+      <a href="/<%= slug %>" class="hover:underline">Gallery</a>
+    <% } else { %>
+      <a href="/" class="hover:underline">Home</a>
+    <% } %>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- create reusable `header.ejs` partial with conditional Home/Gallery link
- include the new header partial in gallery home and artist profile pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893dd731904832082970b44777c6cfd