### PR TITLE
Add hero partial and integrate into gallery and artist views

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -35,7 +35,12 @@ router.get('/faq', (req, res) => {
 router.get('/:gallerySlug', async (req, res) => {
   try {
     const gallery = await getGalleryAsync(req.params.gallerySlug, galleryOptions);
-    res.render('gallery-home', { gallery, slug: req.params.gallerySlug });
+    const heroData = {
+      image: gallery.heroImageUrl,
+      featuredWork: (gallery.featuredArtworks || [])[0],
+      announcement: gallery.announcement
+    };
+    res.render('gallery-home', { gallery, slug: req.params.gallerySlug, heroData });
   } catch (err) {
     send404(res, 'Gallery not found', err);
   }
@@ -52,7 +57,12 @@ router.get('/:gallerySlug/artists/:artistId', async (req, res) => {
 
   try {
     const artist = await getArtistAsync(req.params.gallerySlug, req.params.artistId);
-    res.render('artist-profile', { gallery, artist, slug: req.params.gallerySlug });
+    const heroData = {
+      image: artist.bioImageUrl,
+      featuredWork: (artist.artworks || []).find(a => a.isFeatured),
+      announcement: artist.announcement
+    };
+    res.render('artist-profile', { gallery, artist, slug: req.params.gallerySlug, heroData });
   } catch (err) {
     send404(res, 'Artist not found', err);
   }

--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -10,6 +10,7 @@
   <%- include('partials/header', { gallery, slug }) %>
 
   <main class="max-w-4xl mx-auto p-6">
+    <%- include('partials/hero', { heroData }) %>
     <header class="text-center mb-12">
       <% if (gallery.logo_url) { %>
         <img src="<%= gallery.logo_url %>" alt="<%= gallery.name %> logo" class="mx-auto mb-4 w-16 h-16 object-contain">

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -14,6 +14,7 @@
   <%- include('partials/header', { gallery, slug }) %>
 
   <main class="max-w-4xl mx-auto p-6">
+    <%- include('partials/hero', { heroData }) %>
     <header class="text-center mb-12">
       <% if (gallery.logo_url) { %>
         <img src="<%= gallery.logo_url %>" alt="<%= gallery.name %> logo" class="mx-auto mb-4 w-16 h-16 object-contain">

--- a/views/partials/hero.ejs
+++ b/views/partials/hero.ejs
@@ -1,0 +1,29 @@
+<% if (heroData) { %>
+  <section class="mb-12">
+    <% if (heroData.image) { %>
+      <img src="<%= heroData.image %>" alt="<%= heroData.imageAlt || '' %>" class="w-full h-auto mb-4">
+    <% } %>
+
+    <% if (heroData.featuredWork) { %>
+      <div class="text-center mb-4">
+        <% if (heroData.featuredWork.url) { %>
+          <a href="<%= heroData.featuredWork.url %>" class="block">
+        <% } %>
+          <% if (heroData.featuredWork.image) { %>
+            <img src="<%= heroData.featuredWork.image %>" alt="<%= heroData.featuredWork.title %>" class="w-full h-auto mb-2">
+          <% } %>
+          <h2 class="text-xl font-bold"><%= heroData.featuredWork.title %></h2>
+          <% if (heroData.featuredWork.artist) { %>
+            <p class="text-gray-600"><%= heroData.featuredWork.artist %></p>
+          <% } %>
+        <% if (heroData.featuredWork.url) { %>
+          </a>
+        <% } %>
+      </div>
+    <% } %>
+
+    <% if (heroData.announcement) { %>
+      <p class="text-center text-lg font-semibold"><%= heroData.announcement %></p>
+    <% } %>
+  </section>
+<% } %>


### PR DESCRIPTION
## Summary
- create reusable hero partial supporting image, featured work, or announcement
- render hero partial in gallery home and artist profile pages
- supply hero data from corresponding route handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893de750b0c8320941a275fc308f06e