### PR TITLE
refactor: extract artist list partial

### DIFF
--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -47,13 +47,8 @@
 
     <section>
       <h2 class="text-xl font-bold mb-4">Artists</h2>
-      <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-center">
-        <% gallery.artists.forEach(function(artist){ %>
-          <li>
-            <a href="/<%= slug %>/artists/<%= artist.id %>" class="block p-2 hover:underline"><%= artist.name %></a>
-          </li>
-        <% }) %>
-      </ul>
+      <% const artists = gallery.artists; %>
+      <%- include('partials/artist-list', { artists, slug }) %>
     </section>
 
     <div class="mt-12 text-center">

--- a/views/partials/artist-list.ejs
+++ b/views/partials/artist-list.ejs
@@ -1,0 +1,7 @@
+<ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-center">
+  <% artists.forEach(function(artist){ %>
+    <li>
+      <a href="/<%= slug %>/artists/<%= artist.id %>" class="block p-2 hover:underline"><%= artist.name %></a>
+    </li>
+  <% }) %>
+</ul>


### PR DESCRIPTION
## Summary
- add reusable artist list partial rendering a grid of artists
- use new artist list partial in gallery home template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893e4d914348320b5ffd20da06d5d69