### PR TITLE
Add footer partial for consistent contact info

### DIFF
--- a/views/403.ejs
+++ b/views/403.ejs
@@ -12,5 +12,6 @@
     <p class="text-base mb-4">Your session may have expired or the request was invalid (for example, an incorrect CSRF token).</p>
     <p><a href="/login" class="text-blue-600 underline">Return to login</a> or <a href="/dashboard" class="text-blue-600 underline">go to your dashboard</a>.</p>
   </main>
+  <%- include('partials/footer'); %>
 </body>
 </html>

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -12,5 +12,6 @@
     <p class="text-base mb-4">The page you are looking for doesn't exist.</p>
     <p><a href="/" class="text-blue-600 underline">Return to home</a></p>
   </main>
+  <%- include('partials/footer'); %>
 </body>
 </html>

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -23,8 +23,6 @@
       <a href="/account/password" class="border border-black px-4 py-2 rounded hover:bg-gray-100">Update Password</a>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('partials/footer'); %>
 </body>
 </html>

--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -70,19 +70,7 @@
     </div>
   </main>
 
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <% if (gallery.contact_email || gallery.phone) { %>
-      <div class="mb-2 text-sm">
-        <% if (gallery.contact_email) { %>
-          <p>Contact: <a href="mailto:<%= gallery.contact_email %>" class="underline"><%= gallery.contact_email %></a></p>
-        <% } %>
-        <% if (gallery.phone) { %>
-          <p>Phone: <%= gallery.phone %></p>
-        <% } %>
-      </div>
-    <% } %>
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('partials/footer', { contactEmail: gallery.contact_email, phone: gallery.phone }); %>
   <script src="/js/fade-in.js"></script>
 </body>
 </html>

--- a/views/artwork-detail.ejs
+++ b/views/artwork-detail.ejs
@@ -114,19 +114,7 @@
     </div>
   </main>
 
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <% if (gallery.contact_email || gallery.phone) { %>
-      <div class="mb-2 text-sm">
-        <% if (gallery.contact_email) { %>
-          <p>Contact: <a href="mailto:<%= gallery.contact_email %>" class="underline"><%= gallery.contact_email %></a></p>
-        <% } %>
-        <% if (gallery.phone) { %>
-          <p>Phone: <%= gallery.phone %></p>
-        <% } %>
-      </div>
-    <% } %>
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('partials/footer', { contactEmail: gallery.contact_email, phone: gallery.phone }); %>
   <script src="/js/fade-in.js"></script>
   <script src="/js/artwork-detail.js"></script>
 </body>

--- a/views/csrf-error.ejs
+++ b/views/csrf-error.ejs
@@ -12,5 +12,6 @@
     <p class="text-base mb-4"><%= message %></p>
     <p><a href="javascript:location.reload()" class="text-blue-600 underline">Refresh the page</a> or <a href="/login" class="text-blue-600 underline">log in again</a>.</p>
   </main>
+  <%- include('partials/footer'); %>
 </body>
 </html>

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -41,8 +41,6 @@
       </p>
     </section>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('partials/footer'); %>
 </body>
 </html>

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -61,19 +61,7 @@
     </div>
   </main>
 
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <% if (gallery.contact_email || gallery.phone) { %>
-      <div class="mb-2 text-sm">
-        <% if (gallery.contact_email) { %>
-          <p>Contact: <a href="mailto:<%= gallery.contact_email %>" class="underline"><%= gallery.contact_email %></a></p>
-        <% } %>
-        <% if (gallery.phone) { %>
-          <p>Phone: <%= gallery.phone %></p>
-        <% } %>
-      </div>
-    <% } %>
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('partials/footer', { contactEmail: gallery.contact_email, phone: gallery.phone }); %>
   <script src="/js/fade-in.js"></script>
 </body>
 </html>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -54,8 +54,6 @@
     </div>
   </section>
 
-  <footer class="text-center py-6 border-t border-gray-200">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('partials/footer'); %>
 </body>
 </html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -40,8 +40,6 @@
         <p class="mt-4 text-center"><a href="/" class="text-blue-600 underline">Back home</a></p>
       </div>
     </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('partials/footer'); %>
 </body>
 </html>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,0 +1,11 @@
+<%
+  const email = (typeof contactEmail !== 'undefined' && contactEmail) ? contactEmail : 'support@example.com';
+  const phoneNumber = (typeof phone !== 'undefined' && phone) ? phone : '1-800-123-4567';
+%>
+<footer class="text-center py-6 border-t border-gray-200 mt-12">
+  <div class="mb-2 text-sm">
+    <p>Contact: <a href="mailto:<%= email %>" class="underline"><%= email %></a></p>
+    <p>Phone: <%= phoneNumber %></p>
+  </div>
+  <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
+</footer>

--- a/views/signup/artist.ejs
+++ b/views/signup/artist.ejs
@@ -43,8 +43,6 @@
       </form>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('../partials/footer'); %>
 </body>
 </html>

--- a/views/signup/gallery.ejs
+++ b/views/signup/gallery.ejs
@@ -43,8 +43,6 @@
       </form>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('../partials/footer'); %>
 </body>
 </html>

--- a/views/signup/index.ejs
+++ b/views/signup/index.ejs
@@ -21,8 +21,6 @@
       <a href="/signup/gallery" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded text-base">Sign up as Gallery</a>
     </div>
   </main>
-  <footer class="text-center py-6 border-t border-gray-200 mt-12">
-    <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> FineArtSuite</p>
-  </footer>
+  <%- include('../partials/footer'); %>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create reusable footer partial with contact email, phone, and copyright
- include the footer partial across public-facing views for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e4dc41cc8320aad1e34cfccc2fb1