### PR TITLE
Remove FineArtSuite branding from gallery pages

### DIFF
--- a/views/artist-profile.ejs
+++ b/views/artist-profile.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="font-sans bg-white text-black">
-  <%- include('partials/header', { gallery, slug }) %>
+  <%- include('partials/gallery-header', { gallery, slug }) %>
 
   <main class="max-w-4xl mx-auto p-6">
     <%- include('partials/hero', { heroData }) %>
@@ -44,7 +44,7 @@
     </div>
   </main>
 
-  <%- include('partials/footer', { contactEmail: gallery.contact_email, phone: gallery.phone }); %>
+  <%- include('partials/gallery-footer', { gallery, contactEmail: gallery.contact_email, phone: gallery.phone }); %>
   <script src="/js/fade-in.js"></script>
 </body>
 </html>

--- a/views/gallery-home.ejs
+++ b/views/gallery-home.ejs
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="font-sans bg-white text-black">
-  <%- include('partials/header', { gallery, slug }) %>
+  <%- include('partials/gallery-header', { gallery, slug }) %>
 
   <main class="max-w-4xl mx-auto p-6">
     <%- include('partials/hero', { heroData }) %>
@@ -40,12 +40,9 @@
       <%- include('partials/artist-list', { artists, slug }) %>
     </section>
 
-    <div class="mt-12 text-center">
-      <a class="underline" href="/">Back home</a>
-    </div>
   </main>
 
-  <%- include('partials/footer', { contactEmail: gallery.contact_email, phone: gallery.phone }); %>
+  <%- include('partials/gallery-footer', { gallery, contactEmail: gallery.contact_email, phone: gallery.phone }); %>
   <script src="/js/fade-in.js"></script>
 </body>
 </html>

--- a/views/partials/gallery-footer.ejs
+++ b/views/partials/gallery-footer.ejs
@@ -1,0 +1,15 @@
+<%
+  const email = (typeof contactEmail !== 'undefined' && contactEmail) ? contactEmail : '';
+  const phoneNumber = (typeof phone !== 'undefined' && phone) ? phone : '';
+%>
+<footer class="text-center py-6 border-t border-gray-200 mt-12">
+  <div class="mb-2 text-sm">
+    <% if (email) { %>
+      <p>Contact: <a href="mailto:<%= email %>" class="underline"><%= email %></a></p>
+    <% } %>
+    <% if (phoneNumber) { %>
+      <p>Phone: <%= phoneNumber %></p>
+    <% } %>
+  </div>
+  <p class="text-sm text-gray-500">&copy; <%= new Date().getFullYear() %> <%= gallery.name %></p>
+</footer>

--- a/views/partials/gallery-header.ejs
+++ b/views/partials/gallery-header.ejs
@@ -1,0 +1,3 @@
+<header class="flex items-center justify-center p-4 border-b border-gray-300">
+  <a href="/<%= slug %>" class="text-2xl font-bold"><%= gallery.name %></a>
+</header>


### PR DESCRIPTION
## Summary
- Replace global header/footer on gallery and artist pages with gallery-specific versions
- Add standalone header and footer partials for independent gallery sites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689504c3621c8320817947eaac69fe03