### PR TITLE
Add rate limiting to login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ form for convenience.
 Flash messages are provided using the `connect-flash` middleware. These
 messages give feedback after actions such as logging in or editing records.
 
+### Rate limiting
+
+The `/login` endpoint allows up to five requests per minute from a single IP
+address. When this limit is exceeded the server responds with HTTP 429, which
+helps protect against brute-force attempts.
+
 ### Sessions
 
 Session data is persisted using [`connect-sqlite3`](https://www.npmjs.com/package/connect-sqlite3).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "FineArtSuite is a minimal gallery website project. This repository provides a single HTML file that serves as a starting point for displaying art online.",
   "main": "server.js",
   "scripts": {
-    "test": "node --test",
+    "test": "NODE_ENV=test node --test",
     "start": "node server.js",
     "build:css": "npx tailwindcss -i ./styles/tailwind.css -o ./public/css/main.css --minify"
   },
@@ -23,7 +23,8 @@
     "connect-sqlite3": "^0.9.0",
     "jimp": "^0.22.10",
     "bcrypt": "^5.1.1",
-    "csurf": "^1.11.0"
+    "csurf": "^1.11.0",
+    "express-rate-limit": "^6.7.0"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
## Summary
- limit login attempts to 5 per minute per IP with express-rate-limit
- add express-rate-limit dependency and test-friendly configuration
- document rate limiting in README

## Testing
- `npm install express-rate-limit` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689512be26588320bea0f861e6b4d37f