### PR TITLE
Enforce cascading foreign keys in SQLite schema

### DIFF
--- a/migrations/007_add_foreign_keys.sql
+++ b/migrations/007_add_foreign_keys.sql
@@ -1,0 +1,79 @@
+-- Recreate core tables with foreign key constraints
+PRAGMA foreign_keys=off;
+BEGIN TRANSACTION;
+
+CREATE TABLE artists_new (
+  id TEXT PRIMARY KEY,
+  gallery_slug TEXT,
+  name TEXT,
+  bio TEXT,
+  bioImageUrl TEXT,
+  fullBio TEXT,
+  bio_short TEXT,
+  bio_full TEXT,
+  portrait_url TEXT,
+  gallery_id TEXT,
+  archived INTEGER DEFAULT 0,
+  live INTEGER DEFAULT 0,
+  display_order INTEGER DEFAULT 0,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (gallery_slug) REFERENCES galleries(slug) ON DELETE CASCADE
+);
+INSERT INTO artists_new
+  SELECT id, gallery_slug, name, bio, bioImageUrl, fullBio, bio_short, bio_full,
+         portrait_url, gallery_id, archived, live, display_order, updated_at
+  FROM artists;
+DROP TABLE artists;
+ALTER TABLE artists_new RENAME TO artists;
+
+CREATE TABLE collections_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT,
+  artist_id TEXT,
+  slug TEXT,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (artist_id) REFERENCES artists(id) ON DELETE CASCADE
+);
+INSERT INTO collections_new
+  SELECT id, name, artist_id, slug, updated_at
+  FROM collections;
+DROP TABLE collections;
+ALTER TABLE collections_new RENAME TO collections;
+
+CREATE TABLE artworks_new (
+  id TEXT PRIMARY KEY,
+  artist_id TEXT,
+  gallery_slug TEXT,
+  title TEXT,
+  medium TEXT,
+  custom_medium TEXT,
+  dimensions TEXT,
+  price TEXT,
+  imageFull TEXT,
+  imageStandard TEXT,
+  imageThumb TEXT,
+  status TEXT,
+  hide_collected INTEGER DEFAULT 0,
+  featured INTEGER DEFAULT 0,
+  isVisible INTEGER DEFAULT 1,
+  isFeatured INTEGER DEFAULT 0,
+  description TEXT,
+  framed INTEGER DEFAULT 0,
+  ready_to_hang INTEGER DEFAULT 0,
+  archived INTEGER DEFAULT 0,
+  collection_id INTEGER,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (artist_id) REFERENCES artists(id) ON DELETE CASCADE,
+  FOREIGN KEY (gallery_slug) REFERENCES galleries(slug) ON DELETE CASCADE
+);
+INSERT INTO artworks_new
+  SELECT id, artist_id, gallery_slug, title, medium, custom_medium, dimensions, price,
+         imageFull, imageStandard, imageThumb, status, hide_collected, featured,
+         isVisible, isFeatured, description, framed, ready_to_hang, archived,
+         collection_id, updated_at
+  FROM artworks;
+DROP TABLE artworks;
+ALTER TABLE artworks_new RENAME TO artworks;
+
+COMMIT;
+PRAGMA foreign_keys=on;

--- a/models/artistModel.js
+++ b/models/artistModel.js
@@ -41,16 +41,9 @@ function setArtistLive(id, live, cb) {
 }
 
 function toggleArchive(id, archived, cb) {
-  db.serialize(() => {
-    db.run('BEGIN TRANSACTION');
-    const rollback = err => db.run('ROLLBACK', () => cb(err));
-    db.run('UPDATE artists SET archived = ? WHERE id = ?', [archived, id], err => {
-      if (err) return rollback(err);
-      db.run('UPDATE artworks SET archived = ? WHERE artist_id = ?', [archived, id], err2 => {
-        if (err2) return rollback(err2);
-        db.run('COMMIT', cb);
-      });
-    });
+  db.run('UPDATE artists SET archived = ? WHERE id = ?', [archived, id], err => {
+    if (err) return cb(err);
+    db.run('UPDATE artworks SET archived = ? WHERE artist_id = ?', [archived, id], cb);
   });
 }
 

--- a/models/db.js
+++ b/models/db.js
@@ -9,6 +9,7 @@ const db = new sqlite3.Database(dbFile);
 
 function initialize() {
   db.serialize(() => {
+    db.run('PRAGMA foreign_keys = ON');
     db.run(`CREATE TABLE IF NOT EXISTS galleries (
       slug TEXT PRIMARY KEY,
       name TEXT,
@@ -37,7 +38,8 @@ function initialize() {
       archived INTEGER DEFAULT 0,
       live INTEGER DEFAULT 0,
       display_order INTEGER DEFAULT 0,
-      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (gallery_slug) REFERENCES galleries(slug) ON DELETE CASCADE
     )`);
 
     db.run(`CREATE TABLE IF NOT EXISTS users (
@@ -55,7 +57,8 @@ function initialize() {
       name TEXT,
       artist_id TEXT,
       slug TEXT,
-      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (artist_id) REFERENCES artists(id) ON DELETE CASCADE
     )`);
 
     db.run(`CREATE TABLE IF NOT EXISTS artworks (
@@ -79,7 +82,10 @@ function initialize() {
       framed INTEGER DEFAULT 0,
       ready_to_hang INTEGER DEFAULT 0,
       archived INTEGER DEFAULT 0,
-      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      collection_id INTEGER,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (artist_id) REFERENCES artists(id) ON DELETE CASCADE,
+      FOREIGN KEY (gallery_slug) REFERENCES galleries(slug) ON DELETE CASCADE
     )`);
 
     db.run(`CREATE TRIGGER IF NOT EXISTS galleries_updated_at AFTER UPDATE ON galleries

--- a/seed.js
+++ b/seed.js
@@ -2,9 +2,7 @@ const { db, seed, migrate } = require('./models/db');
 
 migrate(() => {
   db.serialize(() => {
-    db.run('DELETE FROM galleries');
-    db.run('DELETE FROM artists');
-    db.run('DELETE FROM artworks', () => {
+    db.run('DELETE FROM galleries', () => {
       seed(() => {
         console.log('Database seeded');
         db.close();


### PR DESCRIPTION
## Summary
- Enable SQLite foreign keys and define cascading relations for artists, collections, and artworks
- Simplify seed script to rely on cascade behavior
- Remove manual transaction from artist archiving to avoid nested transaction errors
- Add migration to rebuild tables with new foreign key constraints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895127ea45c8320ad0a11a754960fff