### PR TITLE
Support standalone artist pages

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,6 +4,7 @@ const csrf = require('csurf');
 const csrfProtection = csrf();
 const { createUser, findUserByUsername } = require('../models/userModel');
 const { createArtist } = require('../models/artistModel');
+const { generateUniqueSlug } = require('../utils/slug');
 const { createGallery } = require('../models/galleryModel');
 const { db } = require('../models/db');
 const bcrypt = require('../utils/bcrypt');
@@ -58,9 +59,10 @@ function signupHandler(role) {
     }
 
     const { display_name, username, password, passcode } = req.body;
-    let id;
+    let userId;
+    let artistId;
     try {
-      id = await createUser(display_name, username, password, role, passcode);
+      userId = await createUser(display_name, username, password, role, passcode);
     } catch (err) {
       console.error('Error creating user:', err);
       req.flash('error', 'Signup failed. Please try again.');
@@ -69,15 +71,16 @@ function signupHandler(role) {
 
     try {
       if (role === 'artist') {
-        await createArtistAsync(id, display_name, '');
+        artistId = await generateUniqueSlug(db, 'artists', 'id', display_name);
+        await createArtistAsync(artistId, display_name, null);
       } else if (role === 'gallery') {
         await createGalleryAsync(username, display_name);
       }
     } catch (err) {
-      return handleSignupError(id, req, res, role, err);
+      return handleSignupError(userId, req, res, role, err);
     }
 
-    completeSignup(req, res, id, username, role);
+    completeSignup(req, res, artistId || userId, username, role);
   };
 }
 

--- a/routes/public.js
+++ b/routes/public.js
@@ -33,6 +33,21 @@ router.get('/faq', (req, res) => {
   res.render('faq');
 });
 
+// Standalone artist page (no gallery)
+router.get('/artist/:artistId', async (req, res) => {
+  try {
+    const artist = await getArtist(null, req.params.artistId);
+    const heroData = {
+      image: artist.bioImageUrl,
+      featuredWork: (artist.artworks || []).find(a => a.isFeatured),
+      announcement: artist.announcement
+    };
+    res.render('artist-public', { artist, heroData });
+  } catch (err) {
+    send404(res, 'Artist not found', err);
+  }
+});
+
 // Public gallery home page
 router.get('/:gallerySlug', async (req, res) => {
   try {

--- a/views/artist-public.ejs
+++ b/views/artist-public.ejs
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title><%= artist.name %></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body class="font-sans bg-white text-black">
+  <%- include('partials/header') %>
+
+  <main class="max-w-4xl mx-auto p-6">
+    <%- include('partials/hero', { heroData }) %>
+    <header class="text-center mb-12">
+      <h1 class="text-xl md:text-2xl font-bold mb-4"><%= artist.name %></h1>
+      <p class="text-base text-gray-600"><%= artist.bio %></p>
+    </header>
+
+    <section>
+      <h2 class="text-lg md:text-xl font-bold mb-4">Artworks</h2>
+      <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-4 gap-y-8">
+        <% (artist.artworks || []).forEach(function(art){ %>
+          <li>
+            <img src="<%= art.imageThumb || art.imageStandard %>" alt="<%= art.title %>" loading="lazy" class="w-full mb-2 transition-opacity duration-700 opacity-0" data-fade>
+            <span class="font-semibold block"><%= art.title %></span>
+            <span class="text-sm text-gray-600 block"><%= art.medium %> • <%= art.dimensions %> <% if (art.price) { %>• <%= art.price %><% } %></span>
+          </li>
+        <% }) %>
+      </ul>
+    </section>
+
+    <section class="mt-16 flex flex-col items-center text-center">
+      <% if (artist.bioImageUrl) { %>
+        <img src="<%= artist.bioImageUrl %>" alt="<%= artist.name %> portrait" class="w-36 h-36 rounded-full mb-4 transition-opacity duration-700 opacity-0" loading="lazy" data-fade>
+      <% } %>
+      <div class="space-y-4 max-w-prose">
+        <% if (artist.fullBio) { %>
+          <% artist.fullBio.split('\n\n').forEach(function(par){ %>
+            <p class="text-base"><%= par %></p>
+          <% }) %>
+        <% } %>
+      </div>
+    </section>
+  </main>
+
+  <%- include('partials/footer') %>
+  <script src="/js/fade-in.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Allow artists without gallery association by treating `gallery_slug` as nullable
- Add public route and view for standalone artist profiles
- Generate unique slugs for artist accounts during signup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689512b072488320aae0e6aa3fa3ef89