### PR TITLE
Refactor models to async/await and update routes

### DIFF
--- a/models/artworkModel.js
+++ b/models/artworkModel.js
@@ -1,76 +1,80 @@
 const { db } = require('./db');
 const { randomUUID } = require('crypto');
+const { promisify } = require('util');
 
-function getArtwork(gallerySlug, id, cb) {
+const dbGet = promisify(db.get.bind(db));
+const dbAll = promisify(db.all.bind(db));
+const dbRun = promisify(db.run.bind(db));
+
+async function getArtwork(gallerySlug, id) {
   const query = `SELECT artworks.*, artists.gallery_slug, artists.id as artistId
                  FROM artworks JOIN artists ON artworks.artist_id = artists.id
                  WHERE artworks.id = ? AND artists.gallery_slug = ?
                  AND artworks.archived = 0 AND artists.archived = 0`;
-  db.get(query, [id, gallerySlug], (err, row) => {
-    if (err || !row) return cb(err || new Error('Not found'));
-    const artwork = {
-      id: row.id,
-      title: row.title,
-      medium: row.medium,
-      dimensions: row.dimensions,
-      price: row.price,
-      imageFull: row.imageFull,
-      imageStandard: row.imageStandard,
-      imageThumb: row.imageThumb,
-      status: row.status,
-      hide_collected: row.hide_collected,
-      isVisible: row.isVisible,
-      isFeatured: row.isFeatured,
-      description: row.description,
-      framed: row.framed,
-      readyToHang: row.ready_to_hang
-    };
-    cb(null, { artwork, artistId: row.artistId });
-  });
+  const row = await dbGet(query, [id, gallerySlug]);
+  if (!row) throw new Error('Not found');
+  const artwork = {
+    id: row.id,
+    title: row.title,
+    medium: row.medium,
+    dimensions: row.dimensions,
+    price: row.price,
+    imageFull: row.imageFull,
+    imageStandard: row.imageStandard,
+    imageThumb: row.imageThumb,
+    status: row.status,
+    hide_collected: row.hide_collected,
+    isVisible: row.isVisible,
+    isFeatured: row.isFeatured,
+    description: row.description,
+    framed: row.framed,
+    readyToHang: row.ready_to_hang
+  };
+  return { artwork, artistId: row.artistId };
 }
 
-function getArtworksByArtist(artistId, cb) {
-  db.all('SELECT * FROM artworks WHERE artist_id = ? AND archived = 0', [artistId], cb);
+async function getArtworksByArtist(artistId) {
+  return dbAll('SELECT * FROM artworks WHERE artist_id = ? AND archived = 0', [artistId]);
 }
 
-function updateArtworkCollection(id, collectionId, cb) {
-  db.run('UPDATE artworks SET collection_id = ? WHERE id = ?', [collectionId, id], cb);
+async function updateArtworkCollection(id, collectionId) {
+  await dbRun('UPDATE artworks SET collection_id = ? WHERE id = ?', [collectionId, id]);
 }
 
-function createArtwork(artistId, title, medium, dimensions, price, description, framed, readyToHang, images, isFeatured, cb) {
-  db.get('SELECT gallery_slug FROM artists WHERE id = ?', [artistId], (err, row) => {
-    if (err || !row) return cb(err || new Error('Artist not found'));
-    const id = randomUUID();
-    const stmt = `INSERT INTO artworks (id, artist_id, gallery_slug, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured, description, framed, ready_to_hang)
+async function createArtwork(artistId, title, medium, dimensions, price, description, framed, readyToHang, images, isFeatured) {
+  const row = await dbGet('SELECT gallery_slug FROM artists WHERE id = ?', [artistId]);
+  if (!row) throw new Error('Artist not found');
+  const id = randomUUID();
+  const stmt = `INSERT INTO artworks (id, artist_id, gallery_slug, title, medium, dimensions, price, imageFull, imageStandard, imageThumb, status, isVisible, isFeatured, description, framed, ready_to_hang)
                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
-    const params = [
-      id,
-      artistId,
-      row.gallery_slug,
-      title,
-      medium,
-      dimensions,
-      price || '',
-      images.imageFull,
-      images.imageStandard,
-      images.imageThumb,
-      'available',
-      1,
-      isFeatured ? 1 : 0,
-      description || '',
-      framed ? 1 : 0,
-      readyToHang ? 1 : 0
-    ];
-    db.run(stmt, params, err2 => cb(err2, id));
-  });
+  const params = [
+    id,
+    artistId,
+    row.gallery_slug,
+    title,
+    medium,
+    dimensions,
+    price || '',
+    images.imageFull,
+    images.imageStandard,
+    images.imageThumb,
+    'available',
+    1,
+    isFeatured ? 1 : 0,
+    description || '',
+    framed ? 1 : 0,
+    readyToHang ? 1 : 0
+  ];
+  await dbRun(stmt, params);
+  return id;
 }
 
-function archiveArtwork(id, cb) {
-  db.run('UPDATE artworks SET archived = 1 WHERE id = ?', [id], cb);
+async function archiveArtwork(id) {
+  await dbRun('UPDATE artworks SET archived = 1 WHERE id = ?', [id]);
 }
 
-function unarchiveArtwork(id, cb) {
-  db.run('UPDATE artworks SET archived = 0 WHERE id = ?', [id], cb);
+async function unarchiveArtwork(id) {
+  await dbRun('UPDATE artworks SET archived = 0 WHERE id = ?', [id]);
 }
 
 module.exports = {

--- a/models/galleryModel.js
+++ b/models/galleryModel.js
@@ -1,85 +1,84 @@
 const { db } = require('./db');
+const { promisify } = require('util');
 
-function getGallery(slug, options, cb) {
-  if (typeof options === 'function') {
-    cb = options;
-    options = {};
-  }
-  const { includeArchivedArtists = false, includeArchivedArtworks = false } =
-    options || {};
+const dbGet = promisify(db.get.bind(db));
+const dbAll = promisify(db.all.bind(db));
+const dbRun = promisify(db.run.bind(db));
+
+async function getGallery(slug, options = {}) {
+  const { includeArchivedArtists = false, includeArchivedArtworks = false } = options;
 
   const galleryQuery =
     'SELECT slug, name, bio, logo_url, contact_email, phone FROM galleries WHERE slug = ?';
-  db.get(galleryQuery, [slug], (err, gallery) => {
-    if (err || !gallery) return cb(err || new Error('Not found'));
-    const artistCond = includeArchivedArtists ? '' : 'AND a.archived = 0';
-    const liveCond = 'AND a.live = 1';
-    const artworkCond = includeArchivedArtworks ? '' : 'AND w.archived = 0';
-    const sql = `SELECT a.id as artistId, a.name as artistName, a.bio, a.bioImageUrl, a.fullBio, a.archived as artistArchived,
+  const gallery = await dbGet(galleryQuery, [slug]);
+  if (!gallery) throw new Error('Not found');
+
+  const artistCond = includeArchivedArtists ? '' : 'AND a.archived = 0';
+  const liveCond = 'AND a.live = 1';
+  const artworkCond = includeArchivedArtworks ? '' : 'AND w.archived = 0';
+  const sql = `SELECT a.id as artistId, a.name as artistName, a.bio, a.bioImageUrl, a.fullBio, a.archived as artistArchived,
                         w.id as artworkId, w.title, w.medium, w.dimensions, w.price, w.imageFull, w.imageStandard, w.imageThumb,
                         w.status, w.hide_collected, w.isVisible, w.isFeatured, w.description, w.framed, w.ready_to_hang,
                         w.archived as artworkArchived
                  FROM artists a
                  LEFT JOIN artworks w ON w.artist_id = a.id AND w.isVisible = 1 ${artworkCond}
                  WHERE a.gallery_slug = ? ${artistCond} ${liveCond}
-                 ORDER BY a.display_order`; 
-    db.all(sql, [slug], (err2, rows) => {
-      if (err2) return cb(err2);
-      const artistMap = {};
-      const featured = [];
-      rows.forEach(row => {
-        let artist = artistMap[row.artistId];
-        if (!artist) {
-          artist = {
-            id: row.artistId,
-            name: row.artistName,
-            bio: row.bio,
-            bioImageUrl: row.bioImageUrl,
-            fullBio: row.fullBio,
-            archived: row.artistArchived,
-            artworks: []
-          };
-          artistMap[row.artistId] = artist;
-        }
-        if (row.artworkId) {
-          const artwork = {
-            id: row.artworkId,
-            title: row.title,
-            medium: row.medium,
-            dimensions: row.dimensions,
-            price: row.price,
-            imageFull: row.imageFull,
-            imageStandard: row.imageStandard,
-            imageThumb: row.imageThumb,
-            status: row.status,
-            hide_collected: row.hide_collected,
-            isVisible: row.isVisible,
-            isFeatured: row.isFeatured,
-            description: row.description,
-            framed: row.framed,
-            readyToHang: row.ready_to_hang,
-            archived: row.artworkArchived,
-            artistName: row.artistName
-          };
-          artist.artworks.push(artwork);
-          if (artwork.isFeatured) featured.push(artwork);
-        }
-      });
-      // Exclude archived artists and artworks from the returned gallery data
-      const artists = Object.values(artistMap).filter(a => !a.archived);
-      artists.forEach(a => {
-        a.artworks = a.artworks.filter(w => !w.archived);
-      });
-      gallery.artists = artists;
-      gallery.featuredArtworks = featured.filter(w => !w.archived);
-      cb(null, gallery);
-    });
+                 ORDER BY a.display_order`;
+  const rows = await dbAll(sql, [slug]);
+
+  const artistMap = {};
+  const featured = [];
+  rows.forEach(row => {
+    let artist = artistMap[row.artistId];
+    if (!artist) {
+      artist = {
+        id: row.artistId,
+        name: row.artistName,
+        bio: row.bio,
+        bioImageUrl: row.bioImageUrl,
+        fullBio: row.fullBio,
+        archived: row.artistArchived,
+        artworks: []
+      };
+      artistMap[row.artistId] = artist;
+    }
+    if (row.artworkId) {
+      const artwork = {
+        id: row.artworkId,
+        title: row.title,
+        medium: row.medium,
+        dimensions: row.dimensions,
+        price: row.price,
+        imageFull: row.imageFull,
+        imageStandard: row.imageStandard,
+        imageThumb: row.imageThumb,
+        status: row.status,
+        hide_collected: row.hide_collected,
+        isVisible: row.isVisible,
+        isFeatured: row.isFeatured,
+        description: row.description,
+        framed: row.framed,
+        readyToHang: row.ready_to_hang,
+        archived: row.artworkArchived,
+        artistName: row.artistName
+      };
+      artist.artworks.push(artwork);
+      if (artwork.isFeatured) featured.push(artwork);
+    }
   });
+
+  const artists = Object.values(artistMap).filter(a => !a.archived);
+  artists.forEach(a => {
+    a.artworks = a.artworks.filter(w => !w.archived);
+  });
+  gallery.artists = artists;
+  gallery.featuredArtworks = featured.filter(w => !w.archived);
+  return gallery;
 }
 
-function createGallery(slug, name, cb) {
+async function createGallery(slug, name) {
   const stmt = 'INSERT INTO galleries (slug, name) VALUES (?, ?)';
-  db.run(stmt, [slug, name], cb);
+  await dbRun(stmt, [slug, name]);
 }
 
 module.exports = { getGallery, createGallery };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -9,8 +9,6 @@ const { db } = require('../models/db');
 const bcrypt = require('../utils/bcrypt');
 const { promisify } = require('util');
 
-const createArtistAsync = promisify(createArtist);
-const createGalleryAsync = promisify(createGallery);
 const compareAsync = promisify(bcrypt.compare);
 
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
@@ -69,9 +67,9 @@ function signupHandler(role) {
 
     try {
       if (role === 'artist') {
-        await createArtistAsync(id, display_name, '');
+        await createArtist(id, display_name, '');
       } else if (role === 'gallery') {
-        await createGalleryAsync(username, display_name);
+        await createGallery(username, display_name);
       }
     } catch (err) {
       return handleSignupError(id, req, res, role, err);

--- a/routes/dashboard/admin/artists.js
+++ b/routes/dashboard/admin/artists.js
@@ -257,49 +257,49 @@ router.delete('/artists/:id', requireRole('admin', 'gallery'), csrfProtection, (
   }
 });
 
-router.patch('/artists/:id/archive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    archiveArtist(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+router.patch('/artists/:id/archive', requireRole('admin', 'gallery'), csrfProtection, async (req, res) => {
+  const handle = async () => {
+    try {
+      await archiveArtist(req.params.id);
       req.flash('success', 'Artist archived');
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
-    db.get('SELECT gallery_slug FROM artists WHERE id = ?', [req.params.id], (err, row) => {
+    db.get('SELECT gallery_slug FROM artists WHERE id = ?', [req.params.id], async (err, row) => {
       if (err || !row || row.gallery_slug !== req.user.username) {
         return res.status(403).send('Forbidden');
       }
-      handle();
+      await handle();
     });
   } else {
-    handle();
+    await handle();
   }
 });
 
-router.patch('/artists/:id/unarchive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    unarchiveArtist(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+router.patch('/artists/:id/unarchive', requireRole('admin', 'gallery'), csrfProtection, async (req, res) => {
+  const handle = async () => {
+    try {
+      await unarchiveArtist(req.params.id);
       req.flash('success', 'Artist unarchived');
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
-    db.get('SELECT gallery_slug FROM artists WHERE id = ?', [req.params.id], (err, row) => {
+    db.get('SELECT gallery_slug FROM artists WHERE id = ?', [req.params.id], async (err, row) => {
       if (err || !row || row.gallery_slug !== req.user.username) {
         return res.status(403).send('Forbidden');
       }
-      handle();
+      await handle();
     });
   } else {
-    handle();
+    await handle();
   }
 });
 

--- a/routes/dashboard/admin/artworks.js
+++ b/routes/dashboard/admin/artworks.js
@@ -209,47 +209,47 @@ router.put('/artworks/:id', requireRole('admin', 'gallery'), upload.single('imag
   }
 });
 
-router.patch('/artworks/:id/archive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    archiveArtwork(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+router.patch('/artworks/:id/archive', requireRole('admin', 'gallery'), csrfProtection, async (req, res) => {
+  const handle = async () => {
+    try {
+      await archiveArtwork(req.params.id);
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
-    db.get('SELECT gallery_slug FROM artworks WHERE id=?', [req.params.id], (err, row) => {
+    db.get('SELECT gallery_slug FROM artworks WHERE id=?', [req.params.id], async (err, row) => {
       if (err || !row || row.gallery_slug !== req.user.username) {
         return res.status(403).send('Forbidden');
       }
-      handle();
+      await handle();
     });
   } else {
-    handle();
+    await handle();
   }
 });
 
-router.patch('/artworks/:id/unarchive', requireRole('admin', 'gallery'), csrfProtection, (req, res) => {
-  const handle = () => {
-    unarchiveArtwork(req.params.id, err => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('Database error');
-      }
+router.patch('/artworks/:id/unarchive', requireRole('admin', 'gallery'), csrfProtection, async (req, res) => {
+  const handle = async () => {
+    try {
+      await unarchiveArtwork(req.params.id);
       res.sendStatus(204);
-    });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Database error');
+    }
   };
   if (req.user.role === 'gallery') {
-    db.get('SELECT gallery_slug FROM artworks WHERE id=?', [req.params.id], (err, row) => {
+    db.get('SELECT gallery_slug FROM artworks WHERE id=?', [req.params.id], async (err, row) => {
       if (err || !row || row.gallery_slug !== req.user.username) {
         return res.status(403).send('Forbidden');
       }
-      handle();
+      await handle();
     });
   } else {
-    handle();
+    await handle();
   }
 });
 

--- a/routes/public.js
+++ b/routes/public.js
@@ -13,8 +13,6 @@ const galleryOptions = {
 const { getArtist } = require('../models/artistModel');
 const { getArtwork } = require('../models/artworkModel');
 
-const getGalleryAsync = util.promisify(getGallery);
-const getArtworkAsync = util.promisify(getArtwork);
 const dbAll = util.promisify(db.all.bind(db));
 
 // Home route displaying available galleries
@@ -36,7 +34,7 @@ router.get('/faq', (req, res) => {
 // Public gallery home page
 router.get('/:gallerySlug', async (req, res) => {
   try {
-    const gallery = await getGalleryAsync(req.params.gallerySlug, galleryOptions);
+    const gallery = await getGallery(req.params.gallerySlug, galleryOptions);
     const heroData = {
       image: gallery.heroImageUrl,
       featuredWork: (gallery.featuredArtworks || [])[0],
@@ -52,7 +50,7 @@ router.get('/:gallerySlug', async (req, res) => {
 router.get('/:gallerySlug/artists/:artistId', async (req, res) => {
   let gallery;
   try {
-    gallery = await getGalleryAsync(req.params.gallerySlug, galleryOptions);
+    gallery = await getGallery(req.params.gallerySlug, galleryOptions);
   } catch (err) {
     return send404(res, 'Gallery not found', err);
   }
@@ -71,17 +69,17 @@ router.get('/:gallerySlug/artists/:artistId', async (req, res) => {
 });
 
 // Artwork detail page within a gallery
-router.get('/:gallerySlug/artworks/:artworkId', async (req, res) => {
-  let gallery;
-  try {
-    gallery = await getGalleryAsync(req.params.gallerySlug, galleryOptions);
+  router.get('/:gallerySlug/artworks/:artworkId', async (req, res) => {
+    let gallery;
+    try {
+      gallery = await getGallery(req.params.gallerySlug, galleryOptions);
   } catch (err) {
     return send404(res, 'Gallery not found', err);
   }
 
   let result;
   try {
-    result = await getArtworkAsync(req.params.gallerySlug, req.params.artworkId);
+    result = await getArtwork(req.params.gallerySlug, req.params.artworkId);
   } catch (err) {
     return send404(res, 'Artwork not found', err);
   }

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -326,9 +326,7 @@ test('artist can upload artwork without specifying artist_id', async () => {
   const username = `artist${randomUUID()}`;
   const password = 'password';
   const artistId = await createUser('Artist Test', username, password, 'artist', 'taos');
-  await new Promise((resolve, reject) => {
-    createArtist(artistId, 'Artist Test', 'demo-gallery', 1, err => err ? reject(err) : resolve());
-  });
+  await createArtist(artistId, 'Artist Test', 'demo-gallery', 1);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -432,7 +430,7 @@ test('artist artwork submission rejects invalid CSRF token', async () => {
   const port = server.address().port;
   const username = `artist${randomUUID()}`;
   const userId = await createUser('Artist', username, 'pass', 'artist', 'taos');
-  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', 1, () => resolve()));
+  await createArtist(userId, 'Artist', 'demo-gallery', 1);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -456,7 +454,7 @@ test('artist cannot access admin dashboard', async () => {
   const port = server.address().port;
   const username = `artist${randomUUID()}x`;
   const userId = await createUser('Artist2', username, 'pass', 'artist', 'taos');
-  await new Promise(resolve => createArtist(userId, 'Artist2', 'demo-gallery', 1, () => resolve()));
+  await createArtist(userId, 'Artist2', 'demo-gallery', 1);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -473,7 +471,7 @@ test('artist artwork submission succeeds with valid CSRF token', async () => {
   const port = server.address().port;
   const username = `artist${randomUUID()}`;
   const userId = await createUser('Artist', username, 'pass', 'artist', 'taos');
-  await new Promise(resolve => createArtist(userId, 'Artist', 'demo-gallery', 1, () => resolve()));
+  await createArtist(userId, 'Artist', 'demo-gallery', 1);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];
@@ -510,7 +508,7 @@ test('artist can publish site and view public link', async () => {
   const port = server.address().port;
   const username = `pub${randomUUID()}`;
   const userId = await createUser('Pub', username, 'pass', 'artist', 'demo-gallery');
-  await new Promise(resolve => createArtist(userId, 'Pub', 'demo-gallery', 0, () => resolve()));
+  await createArtist(userId, 'Pub', 'demo-gallery', 0);
   const loginPage = await httpGet(`http://localhost:${port}/login`);
   const loginCsrf = extractCsrfToken(loginPage.body);
   let cookie = loginPage.headers['set-cookie'][0].split(';')[0];


### PR DESCRIPTION
## Summary
- refactor artist, gallery, and artwork models to return Promises via async/await
- update route handlers to await model functions and handle errors
- adjust auth, dashboard, and public routes and tests for Promise-based APIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895129558048320993a1f775735ad62