### PR TITLE
feat: add input validation to dashboard routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "connect-sqlite3": "^0.9.0",
     "jimp": "^0.22.10",
     "bcrypt": "^5.1.1",
-    "csurf": "^1.11.0"
+    "csurf": "^1.11.0",
+    "express-validator": "^6.15.0"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
## Summary
- add express-validator dependency
- validate auth signup/login requests and dashboard artist/artwork operations
- return clear errors for invalid input across forms and APIs

## Testing
- `npm test` *(fails: Cannot find module 'express-validator')*


------
https://chatgpt.com/codex/tasks/task_e_689512a1506c8320bc0cb3676039fd30