### PR TITLE
Add Artist Portfolios section to home page

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -17,14 +17,23 @@ const getGalleryAsync = util.promisify(getGallery);
 const getArtworkAsync = util.promisify(getArtwork);
 const dbAll = util.promisify(db.all.bind(db));
 
-// Home route displaying available galleries
+// Home route displaying available galleries and standalone artist portfolios
 router.get('/', (req, res) => {
-  db.all('SELECT slug, name FROM galleries', (err, rows) => {
-    if (err) {
-      console.error('Error loading galleries:', err);
+  db.all('SELECT slug, name FROM galleries', (gErr, gRows) => {
+    if (gErr) {
+      console.error('Error loading galleries:', gErr);
     }
-    const galleries = err ? [] : rows;
-    res.render('home', { galleries });
+    const galleries = gErr ? [] : gRows;
+
+    const artistSql =
+      'SELECT id, name FROM artists WHERE gallery_slug IS NULL AND archived = 0 AND live = 1';
+    db.all(artistSql, (aErr, aRows) => {
+      if (aErr) {
+        console.error('Error loading artists:', aErr);
+      }
+      const artists = aErr ? [] : aRows;
+      res.render('home', { galleries, artists });
+    });
   });
 });
 

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -37,6 +37,21 @@
     </ul>
   </section>
 
+  <section id="artists" class="max-w-4xl mx-auto px-4 py-12">
+    <h2 class="text-xl font-bold mb-6 text-center">Artist Portfolios</h2>
+    <% if (artists && artists.length) { %>
+      <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-center">
+        <% artists.forEach(a => { %>
+          <li>
+            <a href="/artist/<%= a.id %>" class="block border border-gray-200 p-4 hover:bg-gray-50"><%= a.name %></a>
+          </li>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p class="text-center text-gray-600">No artist portfolios available.</p>
+    <% } %>
+  </section>
+
   <section class="bg-gray-50 py-16 px-4">
     <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
       <div>


### PR DESCRIPTION
## Summary
- Fetch standalone artist records on the home route and pass them to the template
- Display new "Artist Portfolios" section listing these artists

## Testing
- `npm test` *(fails: upload page redirect test 404 vs 302; total 14 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68951ed96d008320a8b792e5459cd3a2