### PR TITLE
fix: persist artwork collection

### DIFF
--- a/views/dashboard/artworks.ejs
+++ b/views/dashboard/artworks.ejs
@@ -190,10 +190,12 @@
         if (artistSelect) {
           localStorage.setItem('lastArtistId', artistSelect.value);
         }
-        const url = isNew ? '/dashboard/artworks' : '/dashboard/artworks/' + id;
-        const method = isNew ? 'POST' : 'PUT';
+        const url = '/dashboard/artworks';
+        if (!isNew) {
+          data.append('id', id);
+        }
         try {
-          const res = await fetch(url, { method, headers: { 'CSRF-Token': csrfToken }, body: data });
+          const res = await fetch(url, { method: 'POST', headers: { 'CSRF-Token': csrfToken }, body: data });
           if (!res.ok) throw new Error(await res.text() || res.statusText);
           btn.textContent = 'Saved!';
           if (isNew) {


### PR DESCRIPTION
## Summary
- ensure artwork edits always post to unified endpoint
- include artwork id in requests to update collection assignment

## Testing
- `npm test` *(fails: 12 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689521d100f8832094521cbf8c48667f